### PR TITLE
Several bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # tarman
-# Copyright (C) 2024 Alessandro Salerno
+# Copyright (C) 2024 - 2025 Alessandro Salerno
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/include/archive.h
+++ b/include/archive.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/cli/directives/commands.h
+++ b/include/cli/directives/commands.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/cli/directives/lookup.h
+++ b/include/cli/directives/lookup.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -24,8 +24,8 @@
 #include "cli/directives/types.h"
 
 typedef struct {
-  cli_drt_desc_t *table;
-  size_t          num_entries;
+    cli_drt_desc_t *table;
+    size_t          num_entries;
 } cli_lkup_table_t;
 
 bool             cli_lkup_command(const char *command, cli_drt_desc_t *dst);

--- a/include/cli/directives/options.h
+++ b/include/cli/directives/options.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/cli/directives/types.h
+++ b/include/cli/directives/types.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -21,28 +21,28 @@
 #include <stdbool.h>
 
 typedef struct {
-  const char *input;
-  bool        from_url;
-  bool        from_repo;
-  const char *pkg_fmt;
-  const char *pkg_name;
-  const char *app_name;
-  const char *exec_path;
-  const char *working_dir;
-  const char *icon_path;
-  bool        add_path;
-  bool        add_desktop;
-  bool        add_tarman;
+    const char *input;
+    bool        from_url;
+    bool        from_repo;
+    const char *pkg_fmt;
+    const char *pkg_name;
+    const char *app_name;
+    const char *exec_path;
+    const char *working_dir;
+    const char *icon_path;
+    bool        add_path;
+    bool        add_desktop;
+    bool        add_tarman;
 } cli_info_t;
 
 typedef bool (*cli_fcn_t)(cli_info_t *info, const char *next);
 typedef int (*cli_exec_t)(cli_info_t info);
 
 typedef struct {
-  const char *short_option;
-  const char *full_option;
-  cli_fcn_t   handler;
-  bool        has_argument;
-  cli_exec_t  exec_handler;
-  const char *description;
+    const char *short_option;
+    const char *full_option;
+    cli_fcn_t   handler;
+    bool        has_argument;
+    cli_exec_t  exec_handler;
+    const char *description;
 } cli_drt_desc_t;

--- a/include/cli/input.h
+++ b/include/cli/input.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/cli/output.h
+++ b/include/cli/output.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/cli/parser.h
+++ b/include/cli/parser.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/config.h
+++ b/include/config.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -24,19 +24,19 @@
 #include <stdlib.h>
 
 typedef enum {
-  TM_CFG_PARSE_STATUS_NOFILE,
-  TM_CFG_PARSE_STATUS_PERM,
-  TM_CFG_PARSE_STATUS_MALFORMED,
-  TM_CFG_PARSE_STATUS_INVKEY,
-  TM_CFG_PARSE_STATUS_INVVAL,
-  TM_CFG_PARSE_STATUS_ERR,
-  TM_CFG_PARSE_STATUS_OK
+    TM_CFG_PARSE_STATUS_NOFILE,
+    TM_CFG_PARSE_STATUS_PERM,
+    TM_CFG_PARSE_STATUS_MALFORMED,
+    TM_CFG_PARSE_STATUS_INVKEY,
+    TM_CFG_PARSE_STATUS_INVVAL,
+    TM_CFG_PARSE_STATUS_ERR,
+    TM_CFG_PARSE_STATUS_OK
 } cfg_parse_status_t;
 
 typedef enum {
-  TM_CFG_PROP_MATCH_FALSE,
-  TM_CFG_PROP_MATCH_OK,
-  TM_CFG_PROP_MATCH_ERR
+    TM_CFG_PROP_MATCH_FALSE,
+    TM_CFG_PROP_MATCH_OK,
+    TM_CFG_PROP_MATCH_ERR
 } cfg_prop_match_t;
 
 typedef void cfg_generic_info_t;

--- a/include/download.h
+++ b/include/download.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/os/console.h
+++ b/include/os/console.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -22,18 +22,18 @@
 #include <stdlib.h>
 
 typedef struct {
-  size_t rows;
-  size_t columns;
+    size_t rows;
+    size_t columns;
 } csz_t;
 
 typedef enum {
-  TM_COLOR_RED,
-  TM_COLOR_GREEN,
-  TM_COLOR_YELLOW,
-  TM_COLOR_MAGENTA,
-  TM_COLOR_CYAN,
-  TM_COLOR_TEXT,
-  TM_COLOR_RESET
+    TM_COLOR_RED,
+    TM_COLOR_GREEN,
+    TM_COLOR_YELLOW,
+    TM_COLOR_MAGENTA,
+    TM_COLOR_CYAN,
+    TM_COLOR_TEXT,
+    TM_COLOR_RESET
 } color_t;
 
 csz_t os_console_get_sz(void);

--- a/include/os/darwin/tm-os-defs.h
+++ b/include/os/darwin/tm-os-defs.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/os/env.h
+++ b/include/os/env.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/os/exec.h
+++ b/include/os/exec.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/os/fs.h
+++ b/include/os/fs.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -23,33 +23,33 @@
 #include <stdlib.h>
 
 typedef enum {
-  TM_FS_DIROP_STATUS_NOEXIST = 0,
-  TM_FS_DIROP_STATUS_EXIST   = 1,
-  TM_FS_DIROP_STATUS_PERM    = 2,
-  TM_FS_DIROP_STATUS_END     = 3,
-  TM_FS_DIROP_STATUS_ERR     = 4,
-  TM_FS_DIROP_STATUS_OK      = 5
+    TM_FS_DIROP_STATUS_NOEXIST = 0,
+    TM_FS_DIROP_STATUS_EXIST   = 1,
+    TM_FS_DIROP_STATUS_PERM    = 2,
+    TM_FS_DIROP_STATUS_END     = 3,
+    TM_FS_DIROP_STATUS_ERR     = 4,
+    TM_FS_DIROP_STATUS_OK      = 5
 } fs_dirop_status_t;
 
 typedef enum {
-  TM_FS_FILEOP_STATUS_NOEXIST = 0,
-  TM_FS_FILEOP_STATUS_PERM    = 1,
-  TM_FS_FILEOP_STATUS_ERR     = 2,
-  TM_FS_FILEOP_STATUS_OK      = 3
+    TM_FS_FILEOP_STATUS_NOEXIST = 0,
+    TM_FS_FILEOP_STATUS_PERM    = 1,
+    TM_FS_FILEOP_STATUS_ERR     = 2,
+    TM_FS_FILEOP_STATUS_OK      = 3
 } fs_fileop_status_t;
 
 typedef enum {
-  TM_FS_FILETYPE_DIR,
-  TM_FS_FILETYPE_REGULAR,
-  TM_FS_FILETYPE_EXEC,
-  TM_FS_FILETYPE_UNKNOWN
+    TM_FS_FILETYPE_DIR,
+    TM_FS_FILETYPE_REGULAR,
+    TM_FS_FILETYPE_EXEC,
+    TM_FS_FILETYPE_UNKNOWN
 } fs_filetype_t;
 
 typedef void *os_fs_dirstream_t;
 
 typedef struct {
-  fs_filetype_t file_type;
-  const char   *name;
+    fs_filetype_t file_type;
+    const char   *name;
 } fs_dirent_t;
 
 fs_dirop_status_t os_fs_mkdir(const char *path);

--- a/include/os/linux/tm-os-defs.h
+++ b/include/os/linux/tm-os-defs.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/os/no-optional/console.h
+++ b/include/os/no-optional/console.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/os/posix/console.h
+++ b/include/os/posix/console.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/os/posix/env.h
+++ b/include/os/posix/env.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/os/posix/exec.h
+++ b/include/os/posix/exec.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/os/posix/fs.h
+++ b/include/os/posix/fs.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/package.h
+++ b/include/package.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -25,28 +25,28 @@
 
 // Structure for tarman package files (packaage.tarman)
 typedef struct {
-  const char *url;
-  const char *from_repoistory;
-  const char *application_name;
-  const char *executable_path;
-  const char *working_directory;
-  const char *icon_path;
+    const char *url;
+    const char *from_repoistory;
+    const char *application_name;
+    const char *executable_path;
+    const char *working_directory;
+    const char *icon_path;
 } pkg_info_t;
 
 // Structure of tarman recipe fles (recipe.tarman or <packagename>.tarman)
 typedef struct {
-  pkg_info_t  pkg_info;
-  const char *package_format;
-  bool        add_to_path;
-  bool        add_to_desktop;
-  bool        add_to_tarman;
+    pkg_info_t  pkg_info;
+    const char *package_format;
+    bool        add_to_path;
+    bool        add_to_desktop;
+    bool        add_to_tarman;
 } recipe_t;
 
 // "Runtime" recipe
 typedef struct {
-  recipe_t    recipe;
-  const char *pkg_name;
-  bool        is_remote;
+    recipe_t    recipe;
+    const char *pkg_name;
+    bool        is_remote;
 } rt_recipe_t;
 
 cfg_parse_status_t pkg_parse_ftmpkg(pkg_info_t *pkg_info, FILE *pkg_file);

--- a/include/plugin/plugin.h
+++ b/include/plugin/plugin.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/plugin/sdk.h
+++ b/include/plugin/sdk.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -31,9 +31,9 @@
 // This structure uses 16-byte alignment to avoid future
 // strict-aliasing issues
 typedef struct {
-  const char *src;
-  const char *dst;
-  const char *cfg;
+    const char *src;
+    const char *dst;
+    const char *cfg;
 } __attribute__((aligned(16))) sdk_handover_t;
 
 // Run a program on the user's computer

--- a/include/stream.h
+++ b/include/stream.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/tm-mem.h
+++ b/include/tm-mem.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/util/misc.h
+++ b/include/util/misc.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/include/util/pkg.h
+++ b/include/util/pkg.h
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |

--- a/plugins/gnu-tar/Makefile
+++ b/plugins/gnu-tar/Makefile
@@ -1,5 +1,5 @@
 # tarman
-# Copyright (C) 2024 Alessandro Salerno
+# Copyright (C) 2024 - 2025 Alessandro Salerno
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/plugins/gnu-tar/plugin.c
+++ b/plugins/gnu-tar/plugin.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -23,5 +23,5 @@
 #include "plugin/sdk.h"
 
 int plugin_main(sdk_handover_t *handover) {
-  return sdk_exec("tar", "-xf", handover->src, "-C", handover->dst, NULL);
+    return sdk_exec("tar", "-xf", handover->src, "-C", handover->dst, NULL);
 }

--- a/src/common/archive.c
+++ b/src/common/archive.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -31,8 +31,8 @@
 typedef bool (*extract_handler_t)(const char *dst, const char *src);
 
 typedef struct {
-  const char       *file_type;
-  extract_handler_t handler;
+    const char       *file_type;
+    extract_handler_t handler;
 } embedded_extract_t;
 
 static embedded_extract_t extractLookup[] = {{"tar", archive_tar_extract},
@@ -41,71 +41,71 @@ static embedded_extract_t extractLookup[] = {{"tar", archive_tar_extract},
 
 static int
 extcmp(const char *src, const char *ft, size_t src_tail, size_t ft_tail) {
-  for (size_t i = src_tail, j = ft_tail; j > 0; j--, i--) {
-    if (src[i] != ft[j]) {
-      return -1;
+    for (size_t i = src_tail, j = ft_tail; j > 0; j--, i--) {
+        if (src[i] != ft[j]) {
+            return -1;
+        }
     }
-  }
 
-  return 0;
+    return 0;
 }
 
 bool archive_tar_extract(const char *dst, const char *src) {
-  return EXIT_SUCCESS == os_exec("tar", "-xf", src, "-C", dst, NULL);
+    return EXIT_SUCCESS == os_exec("tar", "-xf", src, "-C", dst, NULL);
 }
 
 bool archive_extract(const char *dst, const char *src, const char *file_type) {
-  if (NULL != file_type) {
-    if (plugin_exists(file_type)) {
-      return EXIT_SUCCESS == plugin_run(file_type, dst, src);
+    if (NULL != file_type) {
+        if (plugin_exists(file_type)) {
+            return EXIT_SUCCESS == plugin_run(file_type, dst, src);
+        }
+
+        goto search_embedded;
     }
 
-    goto search_embedded;
-  }
+    // If no file type has been set
+    // Try to find plugin based on file extension
+    // This loop is set up to avoid issues with multiple dots
+    for (const char *cp = src; *cp; cp++) {
+        const char ch   = *cp;
+        const char next = *(cp + 1);
 
-  // If no file type has been set
-  // Try to find plugin based on file extension
-  // This loop is set up to avoid issues with multiple dots
-  for (const char *cp = src; *cp; cp++) {
-    const char ch   = *cp;
-    const char next = *(cp + 1);
-
-    // Check if a dot is found
-    // but avoid cases in which the dot is the last character
-    // alongside cases in which it is used for directories
-    // and finally, cases in which the plugin does not exist
-    if ('.' == ch && 0 != next && isalnum(next) && plugin_exists(cp + 1)) {
-      return EXIT_SUCCESS == plugin_run(cp + 1, dst, src);
+        // Check if a dot is found
+        // but avoid cases in which the dot is the last character
+        // alongside cases in which it is used for directories
+        // and finally, cases in which the plugin does not exist
+        if ('.' == ch && 0 != next && isalnum(next) && plugin_exists(cp + 1)) {
+            return EXIT_SUCCESS == plugin_run(cp + 1, dst, src);
+        }
     }
-  }
 
 search_embedded:
-  // If no plugin was found, this searches for
-  // embedded implementations
-  for (size_t i = 0; i < sizeof extractLookup / sizeof(embedded_extract_t);
-       i++) {
-    embedded_extract_t extractor = extractLookup[i];
+    // If no plugin was found, this searches for
+    // embedded implementations
+    for (size_t i = 0; i < sizeof extractLookup / sizeof(embedded_extract_t);
+         i++) {
+        embedded_extract_t extractor = extractLookup[i];
 
-    if (NULL != file_type) {
-      if (0 == strcmp(extractor.file_type, file_type)) {
-        return extractor.handler(dst, src);
-      }
-      continue;
+        if (NULL != file_type) {
+            if (0 == strcmp(extractor.file_type, file_type)) {
+                return extractor.handler(dst, src);
+            }
+            continue;
+        }
+
+        size_t src_len  = strlen(src);
+        size_t src_tail = src_len - 1;
+        size_t ft_len   = strlen(extractor.file_type);
+        size_t ft_tail  = ft_len - 1;
+
+        if (src_len < ft_len) {
+            continue;
+        }
+
+        if (0 == extcmp(src, extractor.file_type, src_tail, ft_tail)) {
+            return extractor.handler(dst, src);
+        }
     }
 
-    size_t src_len  = strlen(src);
-    size_t src_tail = src_len - 1;
-    size_t ft_len   = strlen(extractor.file_type);
-    size_t ft_tail  = ft_len - 1;
-
-    if (src_len < ft_len) {
-      continue;
-    }
-
-    if (0 == extcmp(src, extractor.file_type, src_tail, ft_tail)) {
-      return extractor.handler(dst, src);
-    }
-  }
-
-  return false;
+    return false;
 }

--- a/src/common/cli/directives/commands/add-repo.c
+++ b/src/common/cli/directives/commands/add-repo.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -29,59 +29,60 @@
 #include "util/misc.h"
 
 int cli_cmd_add_repo(cli_info_t info) {
-  if (NULL == info.input) {
-    cli_out_error("Must specify a package to install'");
-    return EXIT_FAILURE;
-  }
+    if (NULL == info.input) {
+        cli_out_error("Must specify a package to install'");
+        return EXIT_FAILURE;
+    }
 
-  char       *archive_path = NULL;
-  const char *repo_url     = info.input;
-  const char *repo_fmt     = info.pkg_fmt;
-  const char *repos_path   = NULL;
-  int         ret          = EXIT_FAILURE;
+    char       *archive_path = NULL;
+    const char *repo_url     = info.input;
+    const char *repo_fmt     = info.pkg_fmt;
+    const char *repos_path   = NULL;
+    int         ret          = EXIT_FAILURE;
 
-  cli_out_progress("Initializing host file system");
+    cli_out_progress("Initializing host file system");
 
-  if (!os_fs_tm_init()) {
-    cli_out_progress("Failed to inizialize host file system");
-    goto cleanup;
-  }
+    if (!os_fs_tm_init()) {
+        cli_out_progress("Failed to inizialize host file system");
+        goto cleanup;
+    }
 
-  os_fs_tm_dyrepos((char **)&repos_path);
+    os_fs_tm_dyrepos((char **)&repos_path);
 
-  if (NULL == repo_fmt) {
-    cli_out_warning("Repository format not specified, using 'tar.gz'");
-    repo_fmt = "tar.gz";
-  }
+    if (NULL == repo_fmt) {
+        cli_out_warning("Repository format not specified, using 'tar.gz'");
+        repo_fmt = "tar.gz";
+    }
 
-  util_misc_dytmpfile(&archive_path, "__downloaded_repo", repo_fmt);
-  cli_out_progress("Fetching repository from '%s'", repo_url);
+    util_misc_dytmpfile(&archive_path, "__downloaded_repo", repo_fmt);
+    cli_out_progress("Fetching repository from '%s'", repo_url);
 
-  if (!download(archive_path, repo_url)) {
-    cli_out_error("Unable to download package");
-    goto cleanup;
-  }
+    if (!download(archive_path, repo_url)) {
+        cli_out_error("Unable to download package");
+        goto cleanup;
+    }
 
-  cli_out_progress("Extracting repository files");
+    cli_out_progress("Extracting repository files");
 
-  if (!archive_extract(repos_path, archive_path, NULL)) {
-    cli_out_error("Unable to extract archive. You may be missing the plugin "
-                  "for this archive type");
-    goto cleanup;
-  }
+    if (!archive_extract(repos_path, archive_path, NULL)) {
+        cli_out_error(
+            "Unable to extract archive. You may be missing the plugin "
+            "for this archive type");
+        goto cleanup;
+    }
 
-  cli_out_progress("Removing cache '%s'", archive_path);
+    cli_out_progress("Removing cache '%s'", archive_path);
 
-  if (TM_FS_FILEOP_STATUS_OK != os_fs_file_rm(archive_path)) {
-    cli_out_warning("Unable to delete cache");
-  }
+    if (TM_FS_FILEOP_STATUS_OK != os_fs_file_rm(archive_path)) {
+        cli_out_warning("Unable to delete cache");
+    }
 
-  cli_out_success("Repository added successfully");
+    cli_out_success("Repository added successfully");
 
-  ret = EXIT_SUCCESS;
+    ret = EXIT_SUCCESS;
 
 cleanup:
-  mem_safe_free(archive_path);
-  mem_safe_free(repos_path);
-  return ret;
+    mem_safe_free(archive_path);
+    mem_safe_free(repos_path);
+    return ret;
 }

--- a/src/common/cli/directives/commands/help.c
+++ b/src/common/cli/directives/commands/help.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -30,88 +30,88 @@
 #define COLUMN_SEPARATOR_LEN 4
 
 static void print_indent(void) {
-  cli_out_space(BASE_LINE_LEN);
+    cli_out_space(BASE_LINE_LEN);
 }
 
 static size_t find_line_len(cli_drt_desc_t desc) {
-  size_t cmd_len = BASE_LINE_LEN + COLUMN_SEPARATOR_LEN;
+    size_t cmd_len = BASE_LINE_LEN + COLUMN_SEPARATOR_LEN;
 
-  if (NULL != desc.short_option) {
-    cmd_len += strlen(desc.short_option);
-  }
+    if (NULL != desc.short_option) {
+        cmd_len += strlen(desc.short_option);
+    }
 
-  if (NULL != desc.full_option) {
-    cmd_len += strlen(desc.full_option);
-  }
+    if (NULL != desc.full_option) {
+        cmd_len += strlen(desc.full_option);
+    }
 
-  return cmd_len;
+    return cmd_len;
 }
 
 static size_t find_max_line_len(cli_lkup_table_t table) {
-  size_t max_cmd_len = BASE_LINE_LEN + COLUMN_SEPARATOR_LEN;
-  for (size_t i = 0; i < table.num_entries; i++) {
-    cli_drt_desc_t desc    = table.table[i];
-    size_t         cmd_len = find_line_len(desc);
+    size_t max_cmd_len = BASE_LINE_LEN + COLUMN_SEPARATOR_LEN;
+    for (size_t i = 0; i < table.num_entries; i++) {
+        cli_drt_desc_t desc    = table.table[i];
+        size_t         cmd_len = find_line_len(desc);
 
-    if (cmd_len > max_cmd_len) {
-      max_cmd_len = cmd_len;
+        if (cmd_len > max_cmd_len) {
+            max_cmd_len = cmd_len;
+        }
     }
-  }
 
-  return max_cmd_len;
+    return max_cmd_len;
 }
 
 static void
 print_help_line(cli_drt_desc_t desc, size_t max_line_len, csz_t csz) {
-  size_t line_len = find_line_len(desc);
-  size_t rem      = max_line_len - line_len;
+    size_t line_len = find_line_len(desc);
+    size_t rem      = max_line_len - line_len;
 
-  print_indent();
+    print_indent();
 
-  if (NULL != desc.short_option && NULL != desc.full_option) {
-    printf("%s, %s", desc.short_option, desc.full_option);
-  } else if (NULL != desc.short_option) {
-    printf("%s", desc.short_option);
-  } else if (NULL != desc.full_option) {
-    printf("%s", desc.full_option);
-  }
+    if (NULL != desc.short_option && NULL != desc.full_option) {
+        printf("%s, %s", desc.short_option, desc.full_option);
+    } else if (NULL != desc.short_option) {
+        printf("%s", desc.short_option);
+    } else if (NULL != desc.full_option) {
+        printf("%s", desc.full_option);
+    }
 
-  cli_out_space(COLUMN_SEPARATOR_LEN);
-  cli_out_space(rem);
+    cli_out_space(COLUMN_SEPARATOR_LEN);
+    cli_out_space(rem);
 
-  size_t tot_off = max_line_len + COLUMN_SEPARATOR_LEN;
-  cli_out_tab_words(tot_off, desc.description, csz);
+    size_t tot_off = max_line_len + COLUMN_SEPARATOR_LEN;
+    cli_out_tab_words(tot_off, desc.description, csz);
 }
 
 static void
 print_help_list(const char *title, cli_lkup_table_t table, csz_t csz) {
-  printf("%s:\n", title);
+    printf("%s:\n", title);
 
-  size_t max_cmd_len = find_max_line_len(table);
+    size_t max_cmd_len = find_max_line_len(table);
 
-  for (size_t i = 0; i < table.num_entries; i++) {
-    cli_drt_desc_t desc = table.table[i];
-    print_help_line(desc, max_cmd_len, csz);
-  }
+    for (size_t i = 0; i < table.num_entries; i++) {
+        cli_drt_desc_t desc = table.table[i];
+        print_help_line(desc, max_cmd_len, csz);
+    }
 
-  puts("");
+    puts("");
 }
 
 int cli_cmd_help(cli_info_t info) {
-  (void)info;
-  csz_t console_sz = os_console_get_sz();
+    (void)info;
+    csz_t console_sz = os_console_get_sz();
 
-  cli_lkup_table_t cmd_table = cli_lkup_cmdtable();
-  cli_lkup_table_t opt_table = cli_lkup_opttable();
+    cli_lkup_table_t cmd_table = cli_lkup_cmdtable();
+    cli_lkup_table_t opt_table = cli_lkup_opttable();
 
-  puts("tarman by Alessandro Salerno");
-  puts(
-      "The portable, cross-platform, extensible, and simple package manager\n");
+    puts("tarman by Alessandro Salerno");
+    puts("The portable, cross-platform, extensible, and simple package "
+         "manager\n");
 
-  printf("Usage: tarman <command> [<options>] [<package|url|repo>]\n\n");
+    printf("Usage: tarman <command> [<options>] [<package|url|repo>]\n\n");
 
-  print_help_list("COMMANDS", cmd_table, console_sz);
-  print_help_list("OPTIONS", opt_table, console_sz);
+    print_help_list("COMMANDS", cmd_table, console_sz);
+    print_help_list("OPTIONS", opt_table, console_sz);
 
-  return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }

--- a/src/common/cli/directives/commands/install.c
+++ b/src/common/cli/directives/commands/install.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -37,107 +37,101 @@
 
 static const char *
 override_if_src_set(const char *dst, const char *src, bool copy) {
-  if (NULL != src && 0 != src[0]) {
-    if (copy) {
-      char *buf = (char *)malloc(strlen(src) + 1);
-      mem_chkoom(buf);
-      strcpy(buf, src);
-      return buf;
+    if (NULL != src && 0 != src[0]) {
+        if (copy) {
+            char *buf = (char *)malloc(strlen(src) + 1);
+            mem_chkoom(buf);
+            strcpy(buf, src);
+            return buf;
+        }
+
+        return src;
     }
 
-    return src;
-  }
-
-  return dst;
-}
-
-static const char *override_if_dst_unset(const char *dst, const char *src) {
-  if (NULL == dst || 0 == dst[0]) {
-    return src;
-  }
-
-  return dst;
+    return dst;
 }
 
 static void override_recipe(rt_recipe_t *recipe, cli_info_t cli_info) {
-  recipe_t   *rcp = &recipe->recipe;
-  pkg_info_t *pkg = &recipe->recipe.pkg_info;
+    recipe_t   *rcp = &recipe->recipe;
+    pkg_info_t *pkg = &recipe->recipe.pkg_info;
 
-  recipe->pkg_name =
-      override_if_src_set(recipe->pkg_name, cli_info.pkg_name, true);
+    recipe->pkg_name =
+        override_if_src_set(recipe->pkg_name, cli_info.pkg_name, true);
 
-  rcp->package_format =
-      override_if_src_set(rcp->package_format, cli_info.pkg_fmt, true);
-  pkg->url =
-      override_if_src_set(pkg->application_name, cli_info.app_name, true);
-  pkg->executable_path =
-      override_if_src_set(pkg->executable_path, cli_info.exec_path, true);
-  pkg->working_directory =
-      override_if_src_set(pkg->working_directory, cli_info.working_dir, true);
-  pkg->icon_path =
-      override_if_src_set(pkg->icon_path, cli_info.icon_path, true);
+    rcp->package_format =
+        override_if_src_set(rcp->package_format, cli_info.pkg_fmt, true);
+    pkg->url =
+        override_if_src_set(pkg->application_name, cli_info.app_name, true);
+    pkg->executable_path =
+        override_if_src_set(pkg->executable_path, cli_info.exec_path, true);
+    pkg->application_name =
+        override_if_src_set(pkg->application_name, cli_info.app_name, true);
+    pkg->working_directory =
+        override_if_src_set(pkg->working_directory, cli_info.working_dir, true);
+    pkg->icon_path =
+        override_if_src_set(pkg->icon_path, cli_info.icon_path, true);
 
-  rcp->add_to_path    = cli_info.add_path;
-  rcp->add_to_desktop = cli_info.add_desktop;
-  rcp->add_to_tarman  = cli_info.add_tarman;
+    rcp->add_to_path    = cli_info.add_path;
+    rcp->add_to_desktop = cli_info.add_desktop;
+    rcp->add_to_tarman  = cli_info.add_tarman;
 }
 
 static void remove_pkg_cache(const char *archive_path) {
-  cli_out_progress("Removing cache '%s'", archive_path);
+    cli_out_progress("Removing cache '%s'", archive_path);
 
-  if (TM_FS_FILEOP_STATUS_OK != os_fs_file_rm(archive_path)) {
-    cli_out_warning("Unable to delete cache");
-  }
+    if (TM_FS_FILEOP_STATUS_OK != os_fs_file_rm(archive_path)) {
+        cli_out_warning("Unable to delete cache");
+    }
 }
 
 static bool gen_repos_list(char     ***repos_list,
                            size_t     *repos_count,
                            const char *pkg_name,
                            const char *repos_path) {
-  os_fs_dirstream_t repos_stream;
-  fs_dirop_status_t open_status = os_fs_dir_open(&repos_stream, repos_path);
+    os_fs_dirstream_t repos_stream;
+    fs_dirop_status_t open_status = os_fs_dir_open(&repos_stream, repos_path);
 
-  if (TM_FS_DIROP_STATUS_OK != open_status) {
-    cli_out_error("Unable to open repositories directory");
-    return false;
-  }
-
-  fs_dirent_t ent;
-  size_t      repos_buf_sz = 16;
-  char      **repos        = (char **)malloc(repos_buf_sz * sizeof(char *));
-  size_t      i            = 0;
-  mem_chkoom(repos);
-
-  while (TM_FS_DIROP_STATUS_OK == os_fs_dir_next(repos_stream, &ent)) {
-    if (TM_FS_FILETYPE_DIR != ent.file_type) {
-      continue;
+    if (TM_FS_DIROP_STATUS_OK != open_status) {
+        cli_out_error("Unable to open repositories directory");
+        return false;
     }
 
-    char *pkg_recipe = NULL;
-    os_fs_tm_dyrecipe(&pkg_recipe, ent.name, pkg_name);
+    fs_dirent_t ent;
+    size_t      repos_buf_sz = 16;
+    char      **repos        = (char **)malloc(repos_buf_sz * sizeof(char *));
+    size_t      i            = 0;
+    mem_chkoom(repos);
 
-    fs_filetype_t rcp_file_type;
+    while (TM_FS_DIROP_STATUS_OK == os_fs_dir_next(repos_stream, &ent)) {
+        if (TM_FS_FILETYPE_DIR != ent.file_type) {
+            continue;
+        }
 
-    if (TM_FS_FILEOP_STATUS_OK ==
+        char *pkg_recipe = NULL;
+        os_fs_tm_dyrecipe(&pkg_recipe, ent.name, pkg_name);
+
+        fs_filetype_t rcp_file_type;
+
+        if (TM_FS_FILEOP_STATUS_OK ==
             os_fs_file_gettype(&rcp_file_type, pkg_recipe) /* &&
         TM_FS_FILETYPE_REGULAR == rcp_file_type */) {
-      if (repos_buf_sz - 1 == i) {
-        repos_buf_sz *= 2;
-        repos = (char **)realloc(repos, repos_buf_sz * sizeof(char *));
-        mem_chkoom(repos);
-      }
+            if (repos_buf_sz - 1 == i) {
+                repos_buf_sz *= 2;
+                repos = (char **)realloc(repos, repos_buf_sz * sizeof(char *));
+                mem_chkoom(repos);
+            }
 
-      repos[i] = (char *)override_if_src_set(repos[i], ent.name, true);
-      i++;
+            repos[i] = (char *)override_if_src_set(repos[i], ent.name, true);
+            i++;
+        }
+
+        mem_safe_free(pkg_recipe);
     }
 
-    mem_safe_free(pkg_recipe);
-  }
-
-  *repos_count = i;
-  *repos_list  = repos;
-  os_fs_dir_close(repos_stream);
-  return true;
+    *repos_count = i;
+    *repos_list  = repos;
+    os_fs_dir_close(repos_stream);
+    return true;
 }
 
 static size_t user_choose(char      **options,
@@ -145,143 +139,144 @@ static size_t user_choose(char      **options,
                           bool        allow_custom,
                           const char *msg_fmt,
                           ...) {
-  if (1 == options_count && !allow_custom) {
-    return 1;
-  }
+    if (1 == options_count && !allow_custom) {
+        return 1;
+    }
 
-  cli_out_newline();
-  va_list args;
-  va_start(args, msg_fmt);
-  vprintf(msg_fmt, args);
-  va_end(args);
-  putchar(':');
-  cli_out_reset();
-  cli_out_newline();
-
-  size_t range_min = 1;
-
-  if (allow_custom) {
-    cli_out_space(8);
-    printf("0. [Custom]");
     cli_out_newline();
-    range_min = 0;
-  }
-
-  for (size_t i = 0; i < options_count; i++) {
-    cli_out_space(8);
-    printf("%ld. %s", i + 1, options[i]);
-    cli_out_newline();
+    va_list args;
+    va_start(args, msg_fmt);
+    vprintf(msg_fmt, args);
+    va_end(args);
+    putchar(':');
     cli_out_reset();
-  }
+    cli_out_newline();
 
-  return cli_in_int(
-      "Enter the desired option number", range_min, options_count);
+    size_t range_min = 1;
+
+    if (allow_custom) {
+        cli_out_space(8);
+        printf("0. [Custom]");
+        cli_out_newline();
+        range_min = 0;
+    }
+
+    for (size_t i = 0; i < options_count; i++) {
+        cli_out_space(8);
+        printf("%ld. %s", i + 1, options[i]);
+        cli_out_newline();
+        cli_out_reset();
+    }
+
+    return cli_in_int(
+        "Enter the desired option number", range_min, options_count);
 }
 
 static bool find_repository(rt_recipe_t *recipe) {
-  const char *repos_path = NULL;
-  os_fs_tm_dyrepos((char **)&repos_path);
+    const char *repos_path = NULL;
+    os_fs_tm_dyrepos((char **)&repos_path);
 
-  bool   ret         = false;
-  char **repos       = NULL;
-  size_t repos_count = 0;
+    bool   ret         = false;
+    char **repos       = NULL;
+    size_t repos_count = 0;
 
-  if (!gen_repos_list(&repos, &repos_count, recipe->pkg_name, repos_path)) {
-    goto cleanup;
-  }
+    if (!gen_repos_list(&repos, &repos_count, recipe->pkg_name, repos_path)) {
+        goto cleanup;
+    }
 
-  if (0 == repos_count) {
-    cli_out_error("Package '%s' not found in local repositories",
-                  recipe->pkg_name);
-    goto cleanup;
-  }
+    if (0 == repos_count) {
+        cli_out_error("Package '%s' not found in local repositories",
+                      recipe->pkg_name);
+        goto cleanup;
+    }
 
-  unsigned long user_choice = user_choose(
-      repos,
-      repos_count,
-      false,
-      "Multiple repositories found for package '%s', choose between",
-      recipe->pkg_name);
+    unsigned long user_choice = user_choose(
+        repos,
+        repos_count,
+        false,
+        "Multiple repositories found for package '%s', choose between",
+        recipe->pkg_name);
 
-  recipe->recipe.pkg_info.from_repoistory = repos[user_choice - 1];
+    recipe->recipe.pkg_info.from_repoistory = repos[user_choice - 1];
 
-  if (util_pkg_load_recipe(&recipe->recipe,
-                           recipe->recipe.pkg_info.from_repoistory,
-                           recipe->pkg_name,
-                           LOG_ON)) {
-    ret = true;
-  }
+    if (util_pkg_load_recipe(&recipe->recipe,
+                             recipe->recipe.pkg_info.from_repoistory,
+                             recipe->pkg_name,
+                             LOG_ON)) {
+        ret = true;
+    }
 
 cleanup:
-  for (size_t i = 0; i < repos_count; i++) {
-    if (i != user_choice - 1) {
-      mem_safe_free(repos[i]);
+    for (size_t i = 0; i < repos_count; i++) {
+        if (i != user_choice - 1) {
+            mem_safe_free(repos[i]);
+        }
     }
-  }
 
-  mem_safe_free(repos);
-  mem_safe_free(repos_path);
+    mem_safe_free(repos);
+    mem_safe_free(repos_path);
 
-  return ret;
+    return ret;
 }
 
 static bool infer_app_name(rt_recipe_t *recipe, const char *pkg_path) {
-  cli_out_progress("Inferring application name");
+    cli_out_progress("Inferring application name");
 
-  os_fs_dirstream_t stream;
-  fs_dirop_status_t open_status = os_fs_dir_open(&stream, pkg_path);
+    os_fs_dirstream_t stream;
+    fs_dirop_status_t open_status = os_fs_dir_open(&stream, pkg_path);
 
-  if (TM_FS_DIROP_STATUS_OK != open_status) {
-    cli_out_error("Unable to visit package directory '%s'", pkg_path);
-    return false;
-  }
-
-  fs_dirent_t ent;
-  size_t      names_buf_sz = 16;
-  char      **names        = (char **)malloc(names_buf_sz * sizeof(char *));
-  size_t      count        = 1; // Count is one because there's a default value
-  mem_chkoom(names);
-
-  names[0]    = (char *)override_if_src_set(names[0], recipe->pkg_name, true);
-  names[0][0] = toupper(names[0][0]);
-
-  while (TM_FS_DIROP_STATUS_OK == os_fs_dir_next(stream, &ent)) {
-    if (TM_FS_FILETYPE_DIR == ent.file_type) {
-      if (0 == strcmp(ent.name, names[0])) {
-        continue;
-      }
-
-      if (names_buf_sz - 1 == count) {
-        names_buf_sz *= 2;
-        names = (char **)realloc(names, names_buf_sz * sizeof(char *));
-        mem_chkoom(names);
-      }
-
-      names[count] = (char *)override_if_src_set(names[count], ent.name, true);
-      count++;
+    if (TM_FS_DIROP_STATUS_OK != open_status) {
+        cli_out_error("Unable to visit package directory '%s'", pkg_path);
+        return false;
     }
-  }
 
-  os_fs_dir_close(stream);
+    fs_dirent_t ent;
+    size_t      names_buf_sz = 16;
+    char      **names        = (char **)malloc(names_buf_sz * sizeof(char *));
+    size_t      count = 1; // Count is one because there's a default value
+    mem_chkoom(names);
 
-  unsigned long user_choice =
-      user_choose(names, count, true, "Choose an application name");
+    names[0]    = (char *)override_if_src_set(names[0], recipe->pkg_name, true);
+    names[0][0] = toupper(names[0][0]);
 
-  if (0 == user_choice) {
-    cli_in_dystr("Enter working directory",
-                 (char **)&recipe->recipe.pkg_info.application_name);
-  } else {
-    recipe->recipe.pkg_info.application_name = names[user_choice - 1];
-  }
+    while (TM_FS_DIROP_STATUS_OK == os_fs_dir_next(stream, &ent)) {
+        if (TM_FS_FILETYPE_DIR == ent.file_type) {
+            if (0 == strcmp(ent.name, names[0])) {
+                continue;
+            }
 
-  for (size_t i = 0; i < count; i++) {
-    if (i != user_choice - 1) {
-      mem_safe_free(names[i]);
+            if (names_buf_sz - 1 == count) {
+                names_buf_sz *= 2;
+                names = (char **)realloc(names, names_buf_sz * sizeof(char *));
+                mem_chkoom(names);
+            }
+
+            names[count] =
+                (char *)override_if_src_set(names[count], ent.name, true);
+            count++;
+        }
     }
-  }
 
-  mem_safe_free(names);
-  return true;
+    os_fs_dir_close(stream);
+
+    unsigned long user_choice =
+        user_choose(names, count, true, "Choose an application name");
+
+    if (0 == user_choice) {
+        cli_in_dystr("Enter working directory",
+                     (char **)&recipe->recipe.pkg_info.application_name);
+    } else {
+        recipe->recipe.pkg_info.application_name = names[user_choice - 1];
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        if (i != user_choice - 1) {
+            mem_safe_free(names[i]);
+        }
+    }
+
+    mem_safe_free(names);
+    return true;
 }
 
 static bool find_executables(char     ***execs,
@@ -289,278 +284,282 @@ static bool find_executables(char     ***execs,
                              size_t     *bufsz,
                              const char *base_path,
                              const char *subdir) {
-  char *dir_path = (char *)base_path;
+    char *dir_path = (char *)base_path;
 
-  if (NULL != subdir) {
-    os_fs_path_dyconcat(&dir_path, 2, base_path, subdir);
-  }
+    if (NULL != subdir) {
+        os_fs_path_dyconcat(&dir_path, 2, base_path, subdir);
+    }
 
-  os_fs_dirstream_t stream;
-  fs_dirop_status_t open_status = os_fs_dir_open(&stream, dir_path);
-  bool              ret         = false;
+    os_fs_dirstream_t stream;
+    fs_dirop_status_t open_status = os_fs_dir_open(&stream, dir_path);
+    bool              ret         = false;
 
-  if (TM_FS_DIROP_STATUS_OK != open_status) {
-    cli_out_error("Unable to visit subdirectory '%s'", dir_path);
-    goto cleanup;
-  }
+    if (TM_FS_DIROP_STATUS_OK != open_status) {
+        cli_out_error("Unable to visit subdirectory '%s'", dir_path);
+        goto cleanup;
+    }
 
-  fs_dirent_t ent;
+    fs_dirent_t ent;
 
-  while (TM_FS_DIROP_STATUS_OK == os_fs_dir_next(stream, &ent)) {
-    if (TM_FS_FILETYPE_DIR == ent.file_type) {
-      char *sub_subdir = NULL;
+    while (TM_FS_DIROP_STATUS_OK == os_fs_dir_next(stream, &ent)) {
+        if (TM_FS_FILETYPE_DIR == ent.file_type) {
+            char *sub_subdir = NULL;
 
-      if (NULL == subdir) {
-        if (!find_executables(execs, count, bufsz, base_path, ent.name)) {
-          goto close;
+            if (NULL == subdir) {
+                if (!find_executables(
+                        execs, count, bufsz, base_path, ent.name)) {
+                    goto close;
+                }
+                continue;
+            }
+
+            os_fs_path_dyconcat(&sub_subdir, 2, subdir, ent.name);
+
+            if (!find_executables(execs, count, bufsz, base_path, sub_subdir)) {
+                mem_safe_free(sub_subdir);
+                goto close;
+            }
+
+            mem_safe_free(sub_subdir);
         }
-        continue;
-      }
 
-      os_fs_path_dyconcat(&sub_subdir, 2, subdir, ent.name);
+        else if (TM_FS_FILETYPE_EXEC == ent.file_type) {
+            if (*bufsz - 1 == *count) {
+                *bufsz *= 2;
+                *execs = (char **)realloc(*execs, *bufsz * sizeof(char *));
+                mem_chkoom(*execs);
+            }
 
-      if (!find_executables(execs, count, bufsz, base_path, sub_subdir)) {
-        mem_safe_free(sub_subdir);
-        goto close;
-      }
+            char *exec_path = NULL;
+            os_fs_path_dyconcat(&exec_path, 2, subdir, ent.name);
 
-      mem_safe_free(sub_subdir);
+            (*execs)[*count] = exec_path;
+            (*count)++;
+        }
     }
 
-    else if (TM_FS_FILETYPE_EXEC == ent.file_type) {
-      if (*bufsz - 1 == *count) {
-        *bufsz *= 2;
-        *execs = (char **)realloc(*execs, *bufsz * sizeof(char *));
-        mem_chkoom(*execs);
-      }
-
-      char *exec_path = NULL;
-      os_fs_path_dyconcat(&exec_path, 2, subdir, ent.name);
-
-      (*execs)[*count] = exec_path;
-      (*count)++;
-    }
-  }
-
-  ret = true;
+    ret = true;
 
 close:
-  os_fs_dir_close(stream);
+    os_fs_dir_close(stream);
 cleanup:
-  if (NULL != subdir) {
-    mem_safe_free(dir_path);
-  }
+    if (NULL != subdir) {
+        mem_safe_free(dir_path);
+    }
 
-  return ret;
+    return ret;
 }
 
 static bool infer_exec(rt_recipe_t *recipe, const char *pkg_path) {
-  bool          ret          = false;
-  size_t        execs_buf_sz = 16;
-  char        **execs        = (char **)malloc(execs_buf_sz * sizeof(char *));
-  size_t        count        = 0;
-  unsigned long user_choice  = 0;
-  mem_chkoom(execs);
+    bool          ret          = false;
+    size_t        execs_buf_sz = 16;
+    char        **execs        = (char **)malloc(execs_buf_sz * sizeof(char *));
+    size_t        count        = 0;
+    unsigned long user_choice  = 0;
+    mem_chkoom(execs);
 
-  if (find_executables(&execs, &count, &execs_buf_sz, pkg_path, NULL)) {
-    user_choice = user_choose(execs, count, true, "Choose an executable");
-    recipe->recipe.pkg_info.executable_path = execs[user_choice - 1];
-    ret                                     = true;
-  }
-
-  for (size_t i = 0; i < count; i++) {
-    if (i != user_choice - 1) {
-      mem_safe_free(execs[i]);
+    if (find_executables(&execs, &count, &execs_buf_sz, pkg_path, NULL)) {
+        user_choice = user_choose(execs, count, true, "Choose an executable");
+        recipe->recipe.pkg_info.executable_path = execs[user_choice - 1];
+        ret                                     = true;
     }
-  }
 
-  mem_safe_free(execs);
-  return ret;
+    for (size_t i = 0; i < count; i++) {
+        if (i != user_choice - 1) {
+            mem_safe_free(execs[i]);
+        }
+    }
+
+    mem_safe_free(execs);
+    return ret;
 }
 
 static void infer_working_dir(rt_recipe_t *recipe) {
-  cli_out_progress("Inferring working directory");
+    cli_out_progress("Inferring working directory");
 
-  char *parent = NULL;
-  os_fs_path_dyparent(&parent, recipe->recipe.pkg_info.executable_path);
-  recipe->recipe.pkg_info.working_directory = parent;
+    char *parent = NULL;
+    os_fs_path_dyparent(&parent, recipe->recipe.pkg_info.executable_path);
+    recipe->recipe.pkg_info.working_directory = parent;
 }
 
 static bool infer_additional_info(rt_recipe_t *recipe,
                                   cli_info_t   cli_info,
                                   const char  *pkg_path) {
-  if (recipe->is_remote) {
+    if (recipe->is_remote) {
+        return true;
+    }
+
+    if (!recipe->recipe.add_to_path && !cli_info.add_path) {
+        recipe->recipe.add_to_path =
+            cli_in_bool("Do you want to add this package to PATH?");
+    }
+
+    if (NULL == recipe->recipe.pkg_info.executable_path &&
+        !infer_exec(recipe, pkg_path)) {
+        return false;
+    }
+
+    if (!recipe->recipe.add_to_desktop && !cli_info.add_desktop) {
+        recipe->recipe.add_to_desktop =
+            cli_in_bool("Do you want to add this package as an app?");
+    }
+
+    if (recipe->recipe.add_to_desktop &&
+        NULL == recipe->recipe.pkg_info.application_name &&
+        !infer_app_name(recipe, pkg_path)) {
+        return false;
+    }
+
+    if (recipe->recipe.add_to_desktop &&
+        NULL != recipe->recipe.pkg_info.executable_path &&
+        NULL == recipe->recipe.pkg_info.working_directory) {
+        infer_working_dir(recipe);
+    }
+
     return true;
-  }
-
-  if (!recipe->recipe.add_to_path && !cli_info.add_path) {
-    recipe->recipe.add_to_path =
-        cli_in_bool("Do you want to add this package to PATH?");
-  }
-
-  if (NULL == recipe->recipe.pkg_info.executable_path &&
-      !infer_exec(recipe, pkg_path)) {
-    return false;
-  }
-
-  if (!recipe->recipe.add_to_desktop && !cli_info.add_desktop) {
-    recipe->recipe.add_to_desktop =
-        cli_in_bool("Do you want to add this package as an app?");
-  }
-
-  if (recipe->recipe.add_to_desktop &&
-      NULL == recipe->recipe.pkg_info.application_name &&
-      !infer_app_name(recipe, pkg_path)) {
-    return false;
-  }
-
-  if (recipe->recipe.add_to_desktop &&
-      NULL != recipe->recipe.pkg_info.executable_path &&
-      NULL == recipe->recipe.pkg_info.working_directory) {
-    infer_working_dir(recipe);
-  }
-
-  return true;
 }
 
 int cli_cmd_install(cli_info_t info) {
-  if (NULL == info.input) {
-    cli_out_error("Must specify a package to install'");
-    return EXIT_FAILURE;
-  }
-
-  rt_recipe_t recipe = {0};
-  int         ret    = EXIT_FAILURE;
-
-  // Variables to be cleaned up
-  // Declartion is here to avoid issues with goto
-  char       *pkg_path     = NULL;
-  char       *archive_path = NULL;
-  char       *pkg_rcp_path = NULL;
-  const char *exec_path    = NULL;
-
-  cli_out_progress("Initializing host file system");
-
-  if (!os_fs_tm_init()) {
-    cli_out_progress("Failed to inizialize host file system");
-    goto cleanup;
-  }
-
-  cli_out_progress("Initiating installation process");
-
-  override_recipe(&recipe, info);
-
-  if (info.from_url && NULL == recipe.recipe.package_format) {
-    cli_out_warning(
-        "Package format not specified for remote download, using 'tar.gz'");
-    recipe.recipe.package_format =
-        override_if_src_set(recipe.recipe.package_format, "tar.gz", true);
-  }
-
-  // Check if -r is set and use repositories
-  if (info.from_repo) {
-    recipe.is_remote = true;
-    recipe.pkg_name  = override_if_src_set(recipe.pkg_name, info.input, true);
-
-    if (!find_repository(&recipe)) {
-      goto cleanup;
+    if (NULL == info.input) {
+        cli_out_error("Must specify a package to install'");
+        return EXIT_FAILURE;
     }
 
-    if (NULL == recipe.recipe.pkg_info.url) {
-      cli_out_error("Package URL not found in recipe");
-      goto cleanup;
+    rt_recipe_t recipe = {0};
+    int         ret    = EXIT_FAILURE;
+
+    // Variables to be cleaned up
+    // Declartion is here to avoid issues with goto
+    char       *pkg_path     = NULL;
+    char       *archive_path = NULL;
+    char       *pkg_rcp_path = NULL;
+    const char *exec_path    = NULL;
+
+    cli_out_progress("Initializing host file system");
+
+    if (!os_fs_tm_init()) {
+        cli_out_progress("Failed to inizialize host file system");
+        goto cleanup;
     }
 
-    if (!util_pkg_fetch_archive(&archive_path,
-                                recipe.pkg_name,
-                                recipe.recipe.package_format,
-                                recipe.recipe.pkg_info.url,
-                                LOG_ON)) {
-      goto cleanup;
-    }
-  }
+    cli_out_progress("Initiating installation process");
 
-  // Ask user to enter the package name
-  while (NULL == recipe.pkg_name &&
-         0 == cli_in_dystr("Enter package name", (char **)&recipe.pkg_name))
-    ;
+    override_recipe(&recipe, info);
 
-  // If -u is used to download from a URL
-  if (info.from_url) {
-    recipe.recipe.pkg_info.url =
-        override_if_src_set(recipe.recipe.pkg_info.url, info.input, true);
-
-    if (!util_pkg_fetch_archive(&archive_path,
-                                recipe.pkg_name,
-                                recipe.recipe.package_format,
-                                recipe.recipe.pkg_info.url,
-                                LOG_ON)) {
-      goto cleanup;
-    }
-  }
-
-  if (NULL == archive_path) {
-    archive_path = (char *)override_if_src_set(archive_path, info.input, true);
-  }
-
-  if (!util_pkg_create_directory(
-          &pkg_path, recipe.pkg_name, LOG_ON, INPUT_ON)) {
-    goto cleanup;
-  }
-
-  cli_out_progress("Extracting archive '%s' to '%s'", archive_path, pkg_path);
-
-  if (!archive_extract(pkg_path, archive_path, NULL)) {
-    cli_out_error("Unable to extract archive. You may be missing the plugin "
-                  "for this archive type");
-    goto cleanup;
-  }
-
-  if (!recipe.is_remote) {
-    util_pkg_load_config(&recipe.recipe.pkg_info, pkg_path, LOG_ON);
-  }
-
-  if (!infer_additional_info(&recipe, info, pkg_path)) {
-    goto cleanup;
-  }
-
-  os_fs_path_dyconcat(&pkg_rcp_path, 2, pkg_path, "recipe.tarman");
-  cli_out_progress("Creating recipe artifact in '%s'", pkg_rcp_path);
-  pkg_dump_rcp(pkg_rcp_path, recipe.recipe);
-
-  if (NULL != recipe.recipe.pkg_info.executable_path) {
-    os_fs_path_dyconcat((char **)&exec_path,
-                        2,
-                        pkg_path,
-                        recipe.recipe.pkg_info.executable_path);
-
-    if (recipe.recipe.add_to_path) {
-      util_pkg_add_to_path(exec_path, LOG_ON);
+    if (info.from_url && NULL == recipe.recipe.package_format) {
+        cli_out_warning(
+            "Package format not specified for remote download, using 'tar.gz'");
+        recipe.recipe.package_format =
+            override_if_src_set(recipe.recipe.package_format, "tar.gz", true);
     }
 
-    if (recipe.recipe.add_to_desktop) {
-      util_pkg_add_to_desktop(pkg_path,
-                              recipe.recipe.pkg_info.application_name,
-                              exec_path,
-                              recipe.recipe.pkg_info.working_directory,
-                              recipe.recipe.pkg_info.icon_path,
-                              LOG_ON);
+    // Check if -r is set and use repositories
+    if (info.from_repo) {
+        recipe.is_remote = true;
+        recipe.pkg_name =
+            override_if_src_set(recipe.pkg_name, info.input, true);
+
+        if (!find_repository(&recipe)) {
+            goto cleanup;
+        }
+
+        if (NULL == recipe.recipe.pkg_info.url) {
+            cli_out_error("Package URL not found in recipe");
+            goto cleanup;
+        }
+
+        if (!util_pkg_fetch_archive(&archive_path,
+                                    recipe.pkg_name,
+                                    recipe.recipe.package_format,
+                                    recipe.recipe.pkg_info.url,
+                                    LOG_ON)) {
+            goto cleanup;
+        }
     }
-  }
 
-  if ((info.from_url || info.from_repo) && NULL != archive_path) {
-    remove_pkg_cache(archive_path);
-  }
+    // Ask user to enter the package name
+    while (NULL == recipe.pkg_name &&
+           0 == cli_in_dystr("Enter package name", (char **)&recipe.pkg_name))
+        ;
 
-  cli_out_success("Package '%s' installed successfully", recipe.pkg_name);
-  ret = EXIT_SUCCESS;
+    // If -u is used to download from a URL
+    if (info.from_url) {
+        recipe.recipe.pkg_info.url =
+            override_if_src_set(recipe.recipe.pkg_info.url, info.input, true);
+
+        if (!util_pkg_fetch_archive(&archive_path,
+                                    recipe.pkg_name,
+                                    recipe.recipe.package_format,
+                                    recipe.recipe.pkg_info.url,
+                                    LOG_ON)) {
+            goto cleanup;
+        }
+    }
+
+    if (NULL == archive_path) {
+        archive_path =
+            (char *)override_if_src_set(archive_path, info.input, true);
+    }
+
+    if (!util_pkg_create_directory(
+            &pkg_path, recipe.pkg_name, LOG_ON, INPUT_ON)) {
+        goto cleanup;
+    }
+
+    cli_out_progress("Extracting archive '%s' to '%s'", archive_path, pkg_path);
+
+    if (!archive_extract(pkg_path, archive_path, NULL)) {
+        cli_out_error(
+            "Unable to extract archive. You may be missing the plugin "
+            "for this archive type");
+        goto cleanup;
+    }
+
+    if (!recipe.is_remote) {
+        util_pkg_load_config(&recipe.recipe.pkg_info, pkg_path, LOG_ON);
+    }
+
+    if (!infer_additional_info(&recipe, info, pkg_path)) {
+        goto cleanup;
+    }
+
+    os_fs_path_dyconcat(&pkg_rcp_path, 2, pkg_path, "recipe.tarman");
+    cli_out_progress("Creating recipe artifact in '%s'", pkg_rcp_path);
+    pkg_dump_rcp(pkg_rcp_path, recipe.recipe);
+
+    if (NULL != recipe.recipe.pkg_info.executable_path) {
+        os_fs_path_dyconcat((char **)&exec_path,
+                            2,
+                            pkg_path,
+                            recipe.recipe.pkg_info.executable_path);
+
+        if (recipe.recipe.add_to_path) {
+            util_pkg_add_to_path(exec_path, LOG_ON);
+        }
+
+        if (recipe.recipe.add_to_desktop) {
+            util_pkg_add_to_desktop(pkg_path,
+                                    recipe.recipe.pkg_info.application_name,
+                                    exec_path,
+                                    recipe.recipe.pkg_info.working_directory,
+                                    recipe.recipe.pkg_info.icon_path,
+                                    LOG_ON);
+        }
+    }
+
+    if ((info.from_url || info.from_repo) && NULL != archive_path) {
+        remove_pkg_cache(archive_path);
+    }
+
+    cli_out_success("Package '%s' installed successfully", recipe.pkg_name);
+    ret = EXIT_SUCCESS;
 
 cleanup:
-  mem_safe_free(archive_path);
-  mem_safe_free(pkg_path);
-  mem_safe_free(exec_path);
-  mem_safe_free(pkg_rcp_path);
-  mem_safe_free(recipe.pkg_name);
-  pkg_free_rcp(recipe.recipe);
-  return ret;
+    mem_safe_free(archive_path);
+    mem_safe_free(pkg_path);
+    mem_safe_free(exec_path);
+    mem_safe_free(pkg_rcp_path);
+    mem_safe_free(recipe.pkg_name);
+    pkg_free_rcp(recipe.recipe);
+    return ret;
 }

--- a/src/common/cli/directives/commands/list.c
+++ b/src/common/cli/directives/commands/list.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -27,122 +27,122 @@
 #include "tm-mem.h"
 
 static bool find_max_pkg_name_len(size_t *len) {
-  char  *pkg_dir = NULL;
-  bool   ret     = false;
-  size_t max_len = 0;
-  os_fs_tm_dypkgs(&pkg_dir);
+    char  *pkg_dir = NULL;
+    bool   ret     = false;
+    size_t max_len = 0;
+    os_fs_tm_dypkgs(&pkg_dir);
 
-  os_fs_dirstream_t dir_stream;
+    os_fs_dirstream_t dir_stream;
 
-  if (TM_FS_DIROP_STATUS_OK != os_fs_dir_open(&dir_stream, pkg_dir)) {
-    goto cleanup;
-  }
-
-  fs_dirent_t ent;
-  while (TM_FS_DIROP_STATUS_OK == os_fs_dir_next(dir_stream, &ent)) {
-    if (TM_FS_FILETYPE_DIR == ent.file_type) {
-      size_t len = strlen(ent.name);
-
-      if (len > max_len) {
-        max_len = len;
-      }
+    if (TM_FS_DIROP_STATUS_OK != os_fs_dir_open(&dir_stream, pkg_dir)) {
+        goto cleanup;
     }
-  }
 
-  os_fs_dir_close(dir_stream);
-  *len = max_len;
-  ret  = true;
+    fs_dirent_t ent;
+    while (TM_FS_DIROP_STATUS_OK == os_fs_dir_next(dir_stream, &ent)) {
+        if (TM_FS_FILETYPE_DIR == ent.file_type) {
+            size_t len = strlen(ent.name);
+
+            if (len > max_len) {
+                max_len = len;
+            }
+        }
+    }
+
+    os_fs_dir_close(dir_stream);
+    *len = max_len;
+    ret  = true;
 
 cleanup:
-  mem_safe_free(pkg_dir);
-  return ret;
+    mem_safe_free(pkg_dir);
+    return ret;
 }
 
 static void simple_print(void) {
-  char *pkg_dir = NULL;
-  os_fs_tm_dypkgs(&pkg_dir);
+    char *pkg_dir = NULL;
+    os_fs_tm_dypkgs(&pkg_dir);
 
-  os_fs_dirstream_t dir_stream;
+    os_fs_dirstream_t dir_stream;
 
-  if (TM_FS_DIROP_STATUS_OK != os_fs_dir_open(&dir_stream, pkg_dir)) {
-    return;
-  }
-
-  fs_dirent_t ent;
-  while (TM_FS_DIROP_STATUS_OK == os_fs_dir_next(dir_stream, &ent)) {
-    if (TM_FS_FILETYPE_DIR == ent.file_type) {
-      printf("%s", ent.name);
-      cli_out_newline();
+    if (TM_FS_DIROP_STATUS_OK != os_fs_dir_open(&dir_stream, pkg_dir)) {
+        return;
     }
-  }
 
-  os_fs_dir_close(dir_stream);
-  mem_safe_free(pkg_dir);
+    fs_dirent_t ent;
+    while (TM_FS_DIROP_STATUS_OK == os_fs_dir_next(dir_stream, &ent)) {
+        if (TM_FS_FILETYPE_DIR == ent.file_type) {
+            printf("%s", ent.name);
+            cli_out_newline();
+        }
+    }
+
+    os_fs_dir_close(dir_stream);
+    mem_safe_free(pkg_dir);
 }
 
 static void table_print(size_t max_len, size_t width) {
-  char *pkg_dir = NULL;
-  os_fs_tm_dypkgs(&pkg_dir);
+    char *pkg_dir = NULL;
+    os_fs_tm_dypkgs(&pkg_dir);
 
-  os_fs_dirstream_t dir_stream;
+    os_fs_dirstream_t dir_stream;
 
-  if (TM_FS_DIROP_STATUS_OK != os_fs_dir_open(&dir_stream, pkg_dir)) {
-    return;
-  }
-
-  size_t path_space = width - max_len - 8 - 5 - 1;
-
-  fs_dirent_t ent;
-  while (TM_FS_DIROP_STATUS_OK == os_fs_dir_next(dir_stream, &ent)) {
-    if (TM_FS_FILETYPE_DIR == ent.file_type) {
-      size_t ent_len = strlen(ent.name);
-      printf(" --- %s", ent.name);
-
-      size_t padding = max_len - ent_len;
-      cli_out_space(padding);
-      cli_out_space(8);
-
-      char *pkg_path = NULL;
-      os_fs_tm_dypkg(&pkg_path, ent.name);
-      size_t pkg_path_len = strlen(pkg_path);
-
-      if (pkg_path_len < path_space) {
-        printf("%s", pkg_path);
-      } else {
-        char *base = &pkg_path[pkg_path_len - path_space + 5];
-        printf("[...]%s", base);
-      }
-
-      cli_out_newline();
-      mem_safe_free(pkg_path);
+    if (TM_FS_DIROP_STATUS_OK != os_fs_dir_open(&dir_stream, pkg_dir)) {
+        return;
     }
-  }
 
-  os_fs_dir_close(dir_stream);
-  mem_safe_free(pkg_dir);
+    size_t path_space = width - max_len - 8 - 5 - 1;
+
+    fs_dirent_t ent;
+    while (TM_FS_DIROP_STATUS_OK == os_fs_dir_next(dir_stream, &ent)) {
+        if (TM_FS_FILETYPE_DIR == ent.file_type) {
+            size_t ent_len = strlen(ent.name);
+            printf(" --- %s", ent.name);
+
+            size_t padding = max_len - ent_len;
+            cli_out_space(padding);
+            cli_out_space(8);
+
+            char *pkg_path = NULL;
+            os_fs_tm_dypkg(&pkg_path, ent.name);
+            size_t pkg_path_len = strlen(pkg_path);
+
+            if (pkg_path_len < path_space) {
+                printf("%s", pkg_path);
+            } else {
+                char *base = &pkg_path[pkg_path_len - path_space + 5];
+                printf("[...]%s", base);
+            }
+
+            cli_out_newline();
+            mem_safe_free(pkg_path);
+        }
+    }
+
+    os_fs_dir_close(dir_stream);
+    mem_safe_free(pkg_dir);
 }
 
 int cli_cmd_list(cli_info_t info) {
-  (void)info;
+    (void)info;
 
-  if (!os_fs_tm_init()) {
-    cli_out_error("Failed to inizialize host file system");
-    return EXIT_FAILURE;
-  }
+    if (!os_fs_tm_init()) {
+        cli_out_error("Failed to inizialize host file system");
+        return EXIT_FAILURE;
+    }
 
-  csz_t  csz         = os_console_get_sz();
-  size_t max_pkg_len = 0;
+    csz_t  csz         = os_console_get_sz();
+    size_t max_pkg_len = 0;
 
-  if (!find_max_pkg_name_len(&max_pkg_len)) {
-    cli_out_error("Unable to access package directory");
-    return EXIT_FAILURE;
-  }
+    if (!find_max_pkg_name_len(&max_pkg_len)) {
+        cli_out_error("Unable to access package directory");
+        return EXIT_FAILURE;
+    }
 
-  if (csz.columns > max_pkg_len + 8 + 5 + 5) {
-    table_print(max_pkg_len, csz.columns);
+    if (csz.columns > max_pkg_len + 8 + 5 + 5) {
+        table_print(max_pkg_len, csz.columns);
+        return EXIT_SUCCESS;
+    }
+
+    simple_print();
     return EXIT_SUCCESS;
-  }
-
-  simple_print();
-  return EXIT_SUCCESS;
 }

--- a/src/common/cli/directives/commands/misc.c
+++ b/src/common/cli/directives/commands/misc.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -21,11 +21,11 @@
 #include "cli/directives/commands.h"
 
 int cli_cmd_update_all(cli_info_t info) {
-  (void)info;
-  return EXIT_FAILURE;
+    (void)info;
+    return EXIT_FAILURE;
 }
 
 int cli_cmd_list_repos(cli_info_t info) {
-  (void)info;
-  return EXIT_FAILURE;
+    (void)info;
+    return EXIT_FAILURE;
 }

--- a/src/common/cli/directives/commands/remove-repo.c
+++ b/src/common/cli/directives/commands/remove-repo.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -28,63 +28,64 @@
 #include "tm-mem.h"
 
 int cli_cmd_remove_repo(cli_info_t info) {
-  int         ret       = EXIT_FAILURE;
-  const char *repo_name = info.input;
-  char       *repo_path = NULL;
+    int         ret       = EXIT_FAILURE;
+    const char *repo_name = info.input;
+    char       *repo_path = NULL;
 
-  if (NULL == repo_name) {
-    cli_out_error(
-        "You must specify a repository name for it to be removed. Use "
-        "'tarman remove-repo <repo name>'");
-    return ret;
-  }
+    if (NULL == repo_name) {
+        cli_out_error(
+            "You must specify a repository name for it to be removed. Use "
+            "'tarman remove-repo <repo name>'");
+        return ret;
+    }
 
-  cli_out_progress("Initializing host file system");
+    cli_out_progress("Initializing host file system");
 
-  if (!os_fs_tm_init()) {
-    cli_out_progress("Failed to inizialize host file system");
-    goto cleanup;
-  }
+    if (!os_fs_tm_init()) {
+        cli_out_progress("Failed to inizialize host file system");
+        goto cleanup;
+    }
 
-  os_fs_tm_dyrepo(&repo_path, repo_name);
+    os_fs_tm_dyrepo(&repo_path, repo_name);
 
-  os_fs_dirstream_t dir_stream;
+    os_fs_dirstream_t dir_stream;
 
-  switch (os_fs_dir_open(&dir_stream, repo_path)) {
-  case TM_FS_DIROP_STATUS_NOEXIST:
-    cli_out_error("The repository '%s' is not present on this system",
-                  repo_name);
-    goto cleanup;
+    switch (os_fs_dir_open(&dir_stream, repo_path)) {
+    case TM_FS_DIROP_STATUS_NOEXIST:
+        cli_out_error("The repository '%s' is not present on this system",
+                      repo_name);
+        goto cleanup;
 
-  case TM_FS_DIROP_STATUS_OK:
-    break;
+    case TM_FS_DIROP_STATUS_OK:
+        break;
 
-  default:
-    cli_out_error("Unable to open repository directory '%s'", repo_path);
-    goto cleanup;
-  }
+    default:
+        cli_out_error("Unable to open repository directory '%s'", repo_path);
+        goto cleanup;
+    }
 
-  if (TM_FS_DIROP_STATUS_OK != os_fs_dir_close(dir_stream)) {
-    cli_out_error("Error while closing preliminary directory stream to '%s'",
-                  repo_path);
-    goto cleanup;
-  }
+    if (TM_FS_DIROP_STATUS_OK != os_fs_dir_close(dir_stream)) {
+        cli_out_error(
+            "Error while closing preliminary directory stream to '%s'",
+            repo_path);
+        goto cleanup;
+    }
 
-  if (!cli_in_bool("Proceed with removal?")) {
-    goto cleanup;
-  }
+    if (!cli_in_bool("Proceed with removal?")) {
+        goto cleanup;
+    }
 
-  cli_out_progress("Removing repository directory '%s'", repo_path);
+    cli_out_progress("Removing repository directory '%s'", repo_path);
 
-  if (TM_FS_DIROP_STATUS_OK != os_fs_dir_rm(repo_path)) {
-    cli_out_error("Unable to remove repository directory '%s'", repo_path);
-    goto cleanup;
-  }
+    if (TM_FS_DIROP_STATUS_OK != os_fs_dir_rm(repo_path)) {
+        cli_out_error("Unable to remove repository directory '%s'", repo_path);
+        goto cleanup;
+    }
 
-  cli_out_success("Repository '%s' removed successfully", repo_name);
-  ret = EXIT_SUCCESS;
+    cli_out_success("Repository '%s' removed successfully", repo_name);
+    ret = EXIT_SUCCESS;
 
 cleanup:
-  mem_safe_free(repo_path);
-  return ret;
+    mem_safe_free(repo_path);
+    return ret;
 }

--- a/src/common/cli/directives/commands/remove.c
+++ b/src/common/cli/directives/commands/remove.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -28,96 +28,102 @@
 #include "tm-mem.h"
 
 int cli_cmd_remove(cli_info_t info) {
-  int         ret             = EXIT_FAILURE;
-  const char *pkg_name        = info.input;
-  char       *pkg_path        = NULL;
-  char       *artifact_path   = NULL;
-  recipe_t    recipe_artifact = {0};
+    int         ret             = EXIT_FAILURE;
+    const char *pkg_name        = info.input;
+    char       *pkg_path        = NULL;
+    char       *artifact_path   = NULL;
+    recipe_t    recipe_artifact = {0};
 
-  if (NULL == pkg_name) {
-    cli_out_error("You must specify a package name for it to be removed. Use "
-                  "'tarman remove <pkg name>'");
-    return ret;
-  }
-
-  cli_out_progress("Initializing host file system");
-
-  if (!os_fs_tm_init()) {
-    cli_out_progress("Failed to inizialize host file system");
-    goto cleanup;
-  }
-
-  os_fs_tm_dypkg(&pkg_path, pkg_name);
-
-  os_fs_dirstream_t dir_stream;
-
-  switch (os_fs_dir_open(&dir_stream, pkg_path)) {
-  case TM_FS_DIROP_STATUS_NOEXIST:
-    cli_out_error("The package '%s' is not installed on this system, at least "
-                  "not as a tarman package. Try with other package managers "
-                  "you may have on your system");
-    goto cleanup;
-
-  case TM_FS_DIROP_STATUS_OK:
-    break;
-
-  default:
-    cli_out_error("Unable to open package directory '%s'", pkg_path);
-    goto cleanup;
-  }
-
-  if (TM_FS_DIROP_STATUS_OK != os_fs_dir_close(dir_stream)) {
-    cli_out_error("Error while closing preliminary directory stream to '%s'",
-                  pkg_path);
-    goto cleanup;
-  }
-
-  if (!cli_in_bool("Proceed with removal?")) {
-    goto cleanup;
-  }
-
-  os_fs_path_dyconcat(&artifact_path, 2, pkg_path, "recipe.tarman");
-
-  if (pkg_parse_tmrcp(&recipe_artifact, artifact_path)) {
-    if (recipe_artifact.add_to_path) {
-      cli_out_progress("Removing executable from PATH");
-
-      if (!os_env_path_rm(recipe_artifact.pkg_info.executable_path)) {
-        cli_out_warning("Could not remove executable from PATH");
-      }
+    if (NULL == pkg_name) {
+        cli_out_error(
+            "You must specify a package name for it to be removed. Use "
+            "'tarman remove <pkg name>'");
+        return ret;
     }
 
-    if (recipe_artifact.add_to_desktop) {
-      cli_out_progress("Removing app from system applications");
+    cli_out_progress("Initializing host file system");
 
-      if (!os_env_desktop_rm(recipe_artifact.pkg_info.application_name)) {
-        cli_out_warning("Could not remove app from system applications");
-      }
+    if (!os_fs_tm_init()) {
+        cli_out_progress("Failed to inizialize host file system");
+        goto cleanup;
     }
 
-    // TODO: Remove tarman plugin
-  } else {
-    cli_out_warning("Removing package without metadata (recipe artifact), some "
-                    "files may persist");
-  }
+    os_fs_tm_dypkg(&pkg_path, pkg_name);
 
-  cli_out_progress("Removing package directory '%s'", pkg_path);
+    os_fs_dirstream_t dir_stream;
 
-  if (TM_FS_DIROP_STATUS_OK != os_fs_dir_rm(pkg_path)) {
-    cli_out_error("Unable to remove package directory '%s'. The package may "
-                  "now be fully or partially as a result. You can attempt "
-                  "manual removal of the package by deleting the package "
-                  "directory and all PATH or Desktop references that may exist",
-                  pkg_path);
-    goto cleanup;
-  }
+    switch (os_fs_dir_open(&dir_stream, pkg_path)) {
+    case TM_FS_DIROP_STATUS_NOEXIST:
+        cli_out_error(
+            "The package '%s' is not installed on this system, at least "
+            "not as a tarman package. Try with other package managers "
+            "you may have on your system");
+        goto cleanup;
 
-  cli_out_success("Package '%s' removed successfully", pkg_name);
-  ret = EXIT_SUCCESS;
+    case TM_FS_DIROP_STATUS_OK:
+        break;
+
+    default:
+        cli_out_error("Unable to open package directory '%s'", pkg_path);
+        goto cleanup;
+    }
+
+    if (TM_FS_DIROP_STATUS_OK != os_fs_dir_close(dir_stream)) {
+        cli_out_error(
+            "Error while closing preliminary directory stream to '%s'",
+            pkg_path);
+        goto cleanup;
+    }
+
+    if (!cli_in_bool("Proceed with removal?")) {
+        goto cleanup;
+    }
+
+    os_fs_path_dyconcat(&artifact_path, 2, pkg_path, "recipe.tarman");
+
+    if (pkg_parse_tmrcp(&recipe_artifact, artifact_path)) {
+        if (recipe_artifact.add_to_path) {
+            cli_out_progress("Removing executable from PATH");
+
+            if (!os_env_path_rm(recipe_artifact.pkg_info.executable_path)) {
+                cli_out_warning("Could not remove executable from PATH");
+            }
+        }
+
+        if (recipe_artifact.add_to_desktop) {
+            cli_out_progress("Removing app from system applications");
+
+            if (!os_env_desktop_rm(recipe_artifact.pkg_info.application_name)) {
+                cli_out_warning(
+                    "Could not remove app from system applications");
+            }
+        }
+
+        // TODO: Remove tarman plugin
+    } else {
+        cli_out_warning(
+            "Removing package without metadata (recipe artifact), some "
+            "files may persist");
+    }
+
+    cli_out_progress("Removing package directory '%s'", pkg_path);
+
+    if (TM_FS_DIROP_STATUS_OK != os_fs_dir_rm(pkg_path)) {
+        cli_out_error(
+            "Unable to remove package directory '%s'. The package may "
+            "now be fully or partially as a result. You can attempt "
+            "manual removal of the package by deleting the package "
+            "directory and all PATH or Desktop references that may exist",
+            pkg_path);
+        goto cleanup;
+    }
+
+    cli_out_success("Package '%s' removed successfully", pkg_name);
+    ret = EXIT_SUCCESS;
 
 cleanup:
-  mem_safe_free(pkg_path);
-  mem_safe_free(artifact_path);
-  pkg_free_rcp(recipe_artifact);
-  return ret;
+    mem_safe_free(pkg_path);
+    mem_safe_free(artifact_path);
+    pkg_free_rcp(recipe_artifact);
+    return ret;
 }

--- a/src/common/cli/directives/commands/test.c
+++ b/src/common/cli/directives/commands/test.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -26,20 +26,20 @@
 #include "os/fs.h"
 
 #define TARMAN_TEST_INIT() bool tarman_tests_work = true
-#define TARMAN_TEST(val)          \
-  bool tarman_test_##val = val(); \
-  if (!tarman_test_##val) {       \
-    cli_out_error("Test failed"); \
-  }                               \
-  tarman_tests_work = tarman_tests_work && tarman_test_##val;
+#define TARMAN_TEST(val)              \
+    bool tarman_test_##val = val();   \
+    if (!tarman_test_##val) {         \
+        cli_out_error("Test failed"); \
+    }                                 \
+    tarman_tests_work = tarman_tests_work && tarman_test_##val;
 
-#define TARMAN_TEST_END()                      \
-  if (!tarman_tests_work) {                    \
-    cli_out_error("One or more tests failed"); \
-    return EXIT_FAILURE;                       \
-  }                                            \
-  cli_out_success("All tests passed");         \
-  return EXIT_SUCCESS;
+#define TARMAN_TEST_END()                          \
+    if (!tarman_tests_work) {                      \
+        cli_out_error("One or more tests failed"); \
+        return EXIT_FAILURE;                       \
+    }                                              \
+    cli_out_success("All tests passed");           \
+    return EXIT_SUCCESS;
 
 // static bool test_tar(void) {
 //   cli_out_progress("Testing tar extraction...");
@@ -47,48 +47,48 @@
 // }
 
 static bool test_dypath(void) {
-  cli_out_progress("Testing dypath...");
-  char *path;
-  os_fs_tm_dyhome(&path);
-  printf("%s\n", path);
-  return true;
+    cli_out_progress("Testing dypath...");
+    char *path;
+    os_fs_tm_dyhome(&path);
+    printf("%s\n", path);
+    return true;
 }
 
 static bool test_dirs(void) {
-  cli_out_progress("Testing dir creation...");
-  if (TM_FS_DIROP_STATUS_OK != os_fs_mkdir("test")) {
-    return false;
-  }
+    cli_out_progress("Testing dir creation...");
+    if (TM_FS_DIROP_STATUS_OK != os_fs_mkdir("test")) {
+        return false;
+    }
 
-  cli_out_progress("Testing dir enumeration...");
-  size_t count;
-  if (TM_FS_DIROP_STATUS_OK != os_fs_dir_count(&count, "test")) {
-    return false;
-  }
-  printf("Count: %ld, expected: %d\n", count, 0);
-  if (0 != count) {
-    return false;
-  }
+    cli_out_progress("Testing dir enumeration...");
+    size_t count;
+    if (TM_FS_DIROP_STATUS_OK != os_fs_dir_count(&count, "test")) {
+        return false;
+    }
+    printf("Count: %ld, expected: %d\n", count, 0);
+    if (0 != count) {
+        return false;
+    }
 
-  cli_out_progress("Testing dir deletion...");
-  if (TM_FS_DIROP_STATUS_OK != os_fs_dir_rm("test")) {
-    return false;
-  }
+    cli_out_progress("Testing dir deletion...");
+    if (TM_FS_DIROP_STATUS_OK != os_fs_dir_rm("test")) {
+        return false;
+    }
 
-  return true;
+    return true;
 }
 
 static bool test_init(void) {
-  cli_out_progress("Testing fs init...");
-  return os_fs_tm_init();
+    cli_out_progress("Testing fs init...");
+    return os_fs_tm_init();
 }
 
 int cli_cmd_test(cli_info_t info) {
-  (void)info;
-  TARMAN_TEST_INIT();
-  // TARMAN_TEST(test_tar);
-  TARMAN_TEST(test_init);
-  TARMAN_TEST(test_dypath);
-  TARMAN_TEST(test_dirs);
-  TARMAN_TEST_END();
+    (void)info;
+    TARMAN_TEST_INIT();
+    // TARMAN_TEST(test_tar);
+    TARMAN_TEST(test_init);
+    TARMAN_TEST(test_dypath);
+    TARMAN_TEST(test_dirs);
+    TARMAN_TEST_END();
 }

--- a/src/common/cli/directives/commands/update.c
+++ b/src/common/cli/directives/commands/update.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -31,125 +31,131 @@
 #include "util/pkg.h"
 
 int cli_cmd_update(cli_info_t info) {
-  int         ret              = EXIT_FAILURE;
-  const char *pkg_name         = info.input;
-  char       *pkg_path         = NULL;
-  char       *tmp_archive_path = NULL;
-  char       *artifact_path    = NULL;
-  char       *pkg_rcp_path     = NULL;
-  recipe_t    recipe_artifact  = {0};
+    int         ret              = EXIT_FAILURE;
+    const char *pkg_name         = info.input;
+    char       *pkg_path         = NULL;
+    char       *tmp_archive_path = NULL;
+    char       *artifact_path    = NULL;
+    char       *pkg_rcp_path     = NULL;
+    recipe_t    recipe_artifact  = {0};
 
-  if (NULL == pkg_name) {
-    cli_out_error("You must specify a package name for it to be removed. Use "
-                  "'tarman update <pkg name>'");
-    return ret;
-  }
+    if (NULL == pkg_name) {
+        cli_out_error(
+            "You must specify a package name for it to be removed. Use "
+            "'tarman update <pkg name>'");
+        return ret;
+    }
 
-  cli_out_progress("Initializing host file system");
+    cli_out_progress("Initializing host file system");
 
-  if (!os_fs_tm_init()) {
-    cli_out_progress("Failed to inizialize host file system");
-    return ret;
-  }
+    if (!os_fs_tm_init()) {
+        cli_out_progress("Failed to inizialize host file system");
+        return ret;
+    }
 
-  os_fs_tm_dypkg(&pkg_path, pkg_name);
+    os_fs_tm_dypkg(&pkg_path, pkg_name);
 
-  os_fs_path_dyconcat(&artifact_path, 2, pkg_path, "recipe.tarman");
-  cli_out_progress("Using metadata (recipe artifact) file '%s'", artifact_path);
+    os_fs_path_dyconcat(&artifact_path, 2, pkg_path, "recipe.tarman");
+    cli_out_progress("Using metadata (recipe artifact) file '%s'",
+                     artifact_path);
 
-  if (TM_CFG_PARSE_STATUS_OK !=
-      pkg_parse_tmrcp(&recipe_artifact, artifact_path)) {
-    cli_out_error("Cannot update package '%s'. Missing or corrupt metadata "
-                  "(recipe artifact) file",
-                  pkg_name);
-    goto cleanup;
-  }
+    if (TM_CFG_PARSE_STATUS_OK !=
+        pkg_parse_tmrcp(&recipe_artifact, artifact_path)) {
+        cli_out_error("Cannot update package '%s'. Missing or corrupt metadata "
+                      "(recipe artifact) file",
+                      pkg_name);
+        goto cleanup;
+    }
 
-  if (NULL != recipe_artifact.pkg_info.from_repoistory &&
-      !util_pkg_load_recipe(&recipe_artifact,
-                            recipe_artifact.pkg_info.from_repoistory,
-                            pkg_name,
-                            LOG_ON)) {
-    cli_out_warning("Updating using package metadata (recipe artifact) instead "
-                    "of repository recipe");
-  }
-
-  if (NULL == recipe_artifact.pkg_info.url ||
-      NULL == recipe_artifact.package_format) {
-    cli_out_error(
-        "Cannot update package '%s'. Some metadata properties are missing",
-        pkg_name);
-    goto cleanup;
-  }
-
-  if (!util_pkg_fetch_archive(&tmp_archive_path,
+    if (NULL != recipe_artifact.pkg_info.from_repoistory &&
+        !util_pkg_load_recipe(&recipe_artifact,
+                              recipe_artifact.pkg_info.from_repoistory,
                               pkg_name,
-                              recipe_artifact.package_format,
-                              recipe_artifact.pkg_info.url,
                               LOG_ON)) {
-    goto cleanup;
-  }
-
-  cli_out_progress("Removing old package directory '%s'", pkg_path);
-
-  if (TM_FS_DIROP_STATUS_OK != os_fs_dir_rm(pkg_path)) {
-    cli_out_error("Unable to remove package directory '%s'", pkg_path);
-    goto cleanup;
-  }
-
-  if (!util_pkg_create_directory_from_path(pkg_path, LOG_ON, INPUT_OFF)) {
-    goto cleanup;
-  }
-
-  cli_out_progress(
-      "Extracting archive '%s' to '%s'", tmp_archive_path, pkg_path);
-
-  if (!archive_extract(
-          pkg_path, tmp_archive_path, recipe_artifact.package_format)) {
-    cli_out_error("Unable to extract archive, package has been removed but not "
-                  "reinstalled, sorry");
-    goto cleanup;
-  }
-
-  os_fs_path_dyconcat(&pkg_rcp_path, 2, pkg_path, "recipe.tarman");
-  cli_out_progress("Creating recipe artifact in '%s'", pkg_rcp_path);
-  pkg_dump_rcp(pkg_rcp_path, recipe_artifact);
-
-  if (NULL != recipe_artifact.pkg_info.executable_path) {
-    char *exec_full_path = NULL;
-    os_fs_path_dyconcat(
-        &exec_full_path, 2, pkg_path, recipe_artifact.pkg_info.executable_path);
-
-    if (recipe_artifact.add_to_path) {
-      util_pkg_add_to_path(exec_full_path, LOG_ON);
+        cli_out_warning(
+            "Updating using package metadata (recipe artifact) instead "
+            "of repository recipe");
     }
 
-    if (recipe_artifact.add_to_desktop) {
-      util_pkg_add_to_desktop(pkg_path,
-                              recipe_artifact.pkg_info.application_name,
-                              exec_full_path,
-                              recipe_artifact.pkg_info.working_directory,
-                              recipe_artifact.pkg_info.icon_path,
-                              LOG_ON);
+    if (NULL == recipe_artifact.pkg_info.url ||
+        NULL == recipe_artifact.package_format) {
+        cli_out_error(
+            "Cannot update package '%s'. Some metadata properties are missing",
+            pkg_name);
+        goto cleanup;
     }
 
-    mem_safe_free(exec_full_path);
-  }
+    if (!util_pkg_fetch_archive(&tmp_archive_path,
+                                pkg_name,
+                                recipe_artifact.package_format,
+                                recipe_artifact.pkg_info.url,
+                                LOG_ON)) {
+        goto cleanup;
+    }
 
-  cli_out_progress("Removing cache '%s'", tmp_archive_path);
+    cli_out_progress("Removing old package directory '%s'", pkg_path);
 
-  if (TM_FS_FILEOP_STATUS_OK != os_fs_file_rm(tmp_archive_path)) {
-    cli_out_warning("Unable to remove cache");
-  }
+    if (TM_FS_DIROP_STATUS_OK != os_fs_dir_rm(pkg_path)) {
+        cli_out_error("Unable to remove package directory '%s'", pkg_path);
+        goto cleanup;
+    }
 
-  cli_out_success("Package '%s' updated successfully", tmp_archive_path);
-  ret = EXIT_SUCCESS;
+    if (!util_pkg_create_directory_from_path(pkg_path, LOG_ON, INPUT_OFF)) {
+        goto cleanup;
+    }
+
+    cli_out_progress(
+        "Extracting archive '%s' to '%s'", tmp_archive_path, pkg_path);
+
+    if (!archive_extract(
+            pkg_path, tmp_archive_path, recipe_artifact.package_format)) {
+        cli_out_error(
+            "Unable to extract archive, package has been removed but not "
+            "reinstalled, sorry");
+        goto cleanup;
+    }
+
+    os_fs_path_dyconcat(&pkg_rcp_path, 2, pkg_path, "recipe.tarman");
+    cli_out_progress("Creating recipe artifact in '%s'", pkg_rcp_path);
+    pkg_dump_rcp(pkg_rcp_path, recipe_artifact);
+
+    if (NULL != recipe_artifact.pkg_info.executable_path) {
+        char *exec_full_path = NULL;
+        os_fs_path_dyconcat(&exec_full_path,
+                            2,
+                            pkg_path,
+                            recipe_artifact.pkg_info.executable_path);
+
+        if (recipe_artifact.add_to_path) {
+            util_pkg_add_to_path(exec_full_path, LOG_ON);
+        }
+
+        if (recipe_artifact.add_to_desktop) {
+            util_pkg_add_to_desktop(pkg_path,
+                                    recipe_artifact.pkg_info.application_name,
+                                    exec_full_path,
+                                    recipe_artifact.pkg_info.working_directory,
+                                    recipe_artifact.pkg_info.icon_path,
+                                    LOG_ON);
+        }
+
+        mem_safe_free(exec_full_path);
+    }
+
+    cli_out_progress("Removing cache '%s'", tmp_archive_path);
+
+    if (TM_FS_FILEOP_STATUS_OK != os_fs_file_rm(tmp_archive_path)) {
+        cli_out_warning("Unable to remove cache");
+    }
+
+    cli_out_success("Package '%s' updated successfully", tmp_archive_path);
+    ret = EXIT_SUCCESS;
 
 cleanup:
-  mem_safe_free(pkg_path);
-  mem_safe_free(tmp_archive_path);
-  mem_safe_free(artifact_path);
-  mem_safe_free(pkg_rcp_path);
-  pkg_free_rcp(recipe_artifact);
-  return ret;
+    mem_safe_free(pkg_path);
+    mem_safe_free(tmp_archive_path);
+    mem_safe_free(artifact_path);
+    mem_safe_free(pkg_rcp_path);
+    pkg_free_rcp(recipe_artifact);
+    return ret;
 }

--- a/src/common/cli/directives/commands/version.c
+++ b/src/common/cli/directives/commands/version.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -39,10 +39,10 @@
     defined(__GNUC_PATCHLEVEL__) && !defined(__clang__) && \
     !defined(__llvm__) && !defined(__INTEL_COMPILER)
 #define EXT_TARMAN_COMPILER \
-  "gcc " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
+    "gcc " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
 #elif defined(__clang_minor__) && defined(__clang_major__)
 #define EXT_TARMAN_COMPILER \
-  "clang " STR(__clang_major__) "." STR(__clang_minor__)
+    "clang " STR(__clang_major__) "." STR(__clang_minor__)
 #elif defined(__clang__)
 #define EXT_TARMAN_COMPILER "clang (unknown version)"
 #elif defined(__llvm__)
@@ -55,11 +55,11 @@
 #endif // EXT_TARMAN_COMPILER
 
 int cli_cmd_version(cli_info_t info) {
-  (void)info;
+    (void)info;
 
-  puts("tarman version " EXT_TARMAN_BUILD);
-  puts("target: " EXT_TARMAN_OS);
-  puts("compiled with: " EXT_TARMAN_COMPILER);
+    puts("tarman version " EXT_TARMAN_BUILD);
+    puts("target: " EXT_TARMAN_OS);
+    puts("compiled with: " EXT_TARMAN_COMPILER);
 
-  return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }

--- a/src/common/cli/directives/lookup.c
+++ b/src/common/cli/directives/lookup.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -177,40 +177,41 @@ static bool find_desc(cli_drt_desc_t  descriptors[],
                       size_t          num_desc,
                       const char     *arg,
                       cli_drt_desc_t *dst) {
-  for (size_t i = 0; i < num_desc; i++) {
-    cli_drt_desc_t opt_desc = descriptors[i];
+    for (size_t i = 0; i < num_desc; i++) {
+        cli_drt_desc_t opt_desc = descriptors[i];
 
-    if ((NULL == opt_desc.short_option ||
-         0 != strcmp(opt_desc.short_option, arg)) &&
-        (NULL == opt_desc.full_option ||
-         0 != strcmp(opt_desc.full_option, arg))) {
-      continue;
+        if ((NULL == opt_desc.short_option ||
+             0 != strcmp(opt_desc.short_option, arg)) &&
+            (NULL == opt_desc.full_option ||
+             0 != strcmp(opt_desc.full_option, arg))) {
+            continue;
+        }
+
+        *dst = opt_desc;
+        return true;
     }
 
-    *dst = opt_desc;
-    return true;
-  }
-
-  return false;
+    return false;
 }
 
 bool cli_lkup_command(const char *command, cli_drt_desc_t *dst) {
-  return find_desc(
-      commands, sizeof commands / sizeof(cli_drt_desc_t), command, dst);
+    return find_desc(
+        commands, sizeof commands / sizeof(cli_drt_desc_t), command, dst);
 }
 
 bool cli_lkup_option(const char *option, cli_drt_desc_t *dst) {
-  return find_desc(
-      options, sizeof options / sizeof(cli_drt_desc_t), option, dst);
+    return find_desc(
+        options, sizeof options / sizeof(cli_drt_desc_t), option, dst);
 }
 
 cli_lkup_table_t cli_lkup_cmdtable(void) {
-  return (cli_lkup_table_t){.table = commands,
-                            .num_entries =
-                                sizeof commands / sizeof(cli_drt_desc_t)};
+    return (cli_lkup_table_t){.table = commands,
+                              .num_entries =
+                                  sizeof commands / sizeof(cli_drt_desc_t)};
 }
 
 cli_lkup_table_t cli_lkup_opttable(void) {
-  return (cli_lkup_table_t){
-      .table = options, .num_entries = sizeof options / sizeof(cli_drt_desc_t)};
+    return (cli_lkup_table_t){.table = options,
+                              .num_entries =
+                                  sizeof options / sizeof(cli_drt_desc_t)};
 }

--- a/src/common/cli/directives/options.c
+++ b/src/common/cli/directives/options.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -22,88 +22,88 @@
 
 static bool
 set_opt_using_next(const char *opt, const char **target, const char *next) {
-  if (NULL != *target) {
-    cli_out_warning(
-        "Ignoring repeated option '%s' with value '%s', using previous '%s'",
-        opt,
-        next,
-        *target);
-    return true; // Return true anyway since this is just a warning
-  }
+    if (NULL != *target) {
+        cli_out_warning("Ignoring repeated option '%s' with value '%s', using "
+                        "previous '%s'",
+                        opt,
+                        next,
+                        *target);
+        return true; // Return true anyway since this is just a warning
+    }
 
-  if (NULL == next) {
-    cli_out_error("Unexpected end-of-command after last option");
-    return false;
-  }
+    if (NULL == next) {
+        cli_out_error("Unexpected end-of-command after last option");
+        return false;
+    }
 
-  *target = next;
-  return true;
+    *target = next;
+    return true;
 }
 
 bool cli_opt_from_url(cli_info_t *info, const char *next) {
-  (void)next;
-  if (info->from_repo) {
-    cli_out_error("Options '%s' and '%s' are not compatible",
-                  TARMAN_FOPT_FROM_REPO,
-                  TARMAN_FOPT_FROM_URL);
-    return false;
-  }
+    (void)next;
+    if (info->from_repo) {
+        cli_out_error("Options '%s' and '%s' are not compatible",
+                      TARMAN_FOPT_FROM_REPO,
+                      TARMAN_FOPT_FROM_URL);
+        return false;
+    }
 
-  info->from_url = true;
-  return true;
+    info->from_url = true;
+    return true;
 }
 
 bool cli_opt_from_repo(cli_info_t *info, const char *next) {
-  (void)next;
-  if (info->from_url) {
-    cli_out_error("Options '%s' and '%s' are not compatible",
-                  TARMAN_FOPT_FROM_URL,
-                  TARMAN_FOPT_FROM_REPO);
-    return false;
-  }
+    (void)next;
+    if (info->from_url) {
+        cli_out_error("Options '%s' and '%s' are not compatible",
+                      TARMAN_FOPT_FROM_URL,
+                      TARMAN_FOPT_FROM_REPO);
+        return false;
+    }
 
-  info->from_repo = true;
-  return true;
+    info->from_repo = true;
+    return true;
 }
 
 bool cli_opt_pkg_fmt(cli_info_t *info, const char *next) {
-  return set_opt_using_next(TARMAN_FOPT_PKG_FMT, &info->pkg_fmt, next);
+    return set_opt_using_next(TARMAN_FOPT_PKG_FMT, &info->pkg_fmt, next);
 }
 
 bool cli_opt_pkg_name(cli_info_t *info, const char *next) {
-  return set_opt_using_next(TARMAN_FOPT_PKG_NAME, &info->pkg_name, next);
+    return set_opt_using_next(TARMAN_FOPT_PKG_NAME, &info->pkg_name, next);
 }
 
 bool cli_opt_app_name(cli_info_t *info, const char *next) {
-  return set_opt_using_next(TARMAN_FOPT_APP_NAME, &info->app_name, next);
+    return set_opt_using_next(TARMAN_FOPT_APP_NAME, &info->app_name, next);
 }
 
 bool cli_opt_exec(cli_info_t *info, const char *next) {
-  return set_opt_using_next(TARMAN_FOPT_EXEC, &info->exec_path, next);
+    return set_opt_using_next(TARMAN_FOPT_EXEC, &info->exec_path, next);
 }
 
 bool cli_opt_wrk_dir(cli_info_t *info, const char *next) {
-  return set_opt_using_next(TARMAN_FOPT_WRK_DIR, &info->working_dir, next);
+    return set_opt_using_next(TARMAN_FOPT_WRK_DIR, &info->working_dir, next);
 }
 
 bool cli_opt_icon(cli_info_t *info, const char *next) {
-  return set_opt_using_next(TARMAN_FOPT_ICON, &info->icon_path, next);
+    return set_opt_using_next(TARMAN_FOPT_ICON, &info->icon_path, next);
 }
 
 bool cli_opt_add_path(cli_info_t *info, const char *next) {
-  (void)next;
-  info->add_path = true;
-  return true;
+    (void)next;
+    info->add_path = true;
+    return true;
 }
 
 bool cli_opt_add_desktop(cli_info_t *info, const char *next) {
-  (void)next;
-  info->add_desktop = true;
-  return true;
+    (void)next;
+    info->add_desktop = true;
+    return true;
 }
 
 bool cli_opt_add_tarman(cli_info_t *info, const char *next) {
-  (void)next;
-  info->add_tarman = true;
-  return true;
+    (void)next;
+    info->add_tarman = true;
+    return true;
 }

--- a/src/common/cli/input.c
+++ b/src/common/cli/input.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -27,111 +27,112 @@
 #include "stream.h"
 
 static void clear_input_stream(void) {
-  char ch = 0;
-  while (32 < (ch = getchar()) && !feof(stdin))
-    ;
+    char ch = 0;
+    while (32 < (ch = getchar()) && !feof(stdin))
+        ;
 }
 
 int cli_in_int(const char *msg, int range_min, int range_max) {
-  bool use_range = true;
+    bool use_range = true;
 
-  if (range_min == range_max) {
-    use_range = false;
-    range_min = INT_MIN;
-    range_max = INT_MAX;
-  }
-
-  while (true) {
-    int input = 0;
-
-    cli_out_newline();
-
-    if (use_range) {
-      cli_out_prompt("%s [%d, %d]:", msg, range_min, range_max);
-    } else {
-      cli_out_prompt("%s:", msg);
+    if (range_min == range_max) {
+        use_range = false;
+        range_min = INT_MIN;
+        range_max = INT_MAX;
     }
 
-    if (1 != scanf("%d", &input)) {
-      clear_input_stream();
-      cli_out_error("I/O Error: invalid input");
-      continue;
-    }
+    while (true) {
+        int input = 0;
 
-    if (input < range_min || input > range_max) {
-      cli_out_error("Range Error: value '%d' is not valid for range [%d, %d]",
-                    input,
-                    range_min,
-                    range_max);
-      continue;
-    }
+        cli_out_newline();
 
-    clear_input_stream();
-    cli_out_newline();
-    return input;
-  }
+        if (use_range) {
+            cli_out_prompt("%s [%d, %d]:", msg, range_min, range_max);
+        } else {
+            cli_out_prompt("%s:", msg);
+        }
+
+        if (1 != scanf("%d", &input)) {
+            clear_input_stream();
+            cli_out_error("I/O Error: invalid input");
+            continue;
+        }
+
+        if (input < range_min || input > range_max) {
+            cli_out_error(
+                "Range Error: value '%d' is not valid for range [%d, %d]",
+                input,
+                range_min,
+                range_max);
+            continue;
+        }
+
+        clear_input_stream();
+        cli_out_newline();
+        return input;
+    }
 }
 
 bool cli_in_bool(const char *msg) {
-  while (true) {
-    char input = 0;
+    while (true) {
+        char input = 0;
 
-    cli_out_newline();
-    cli_out_prompt("%s [Y/n]:", msg);
+        cli_out_newline();
+        cli_out_prompt("%s [Y/n]:", msg);
 
-    if (1 != scanf("%c", &input)) {
-      clear_input_stream();
-      cli_out_error("I/O Error: invalid input");
-      continue;
+        if (1 != scanf("%c", &input)) {
+            clear_input_stream();
+            cli_out_error("I/O Error: invalid input");
+            continue;
+        }
+
+        if ('\n' == input) {
+            cli_out_newline();
+            return true;
+        }
+
+        clear_input_stream();
+
+        if ('Y' == toupper(input)) {
+            cli_out_newline();
+            return true;
+        }
+
+        if ('n' == tolower(input)) {
+            cli_out_newline();
+            return false;
+        }
+
+        cli_out_error("Range Error: '%c' is not a valid input for range [Y/n]");
     }
-
-    if ('\n' == input) {
-      cli_out_newline();
-      return true;
-    }
-
-    clear_input_stream();
-
-    if ('Y' == toupper(input)) {
-      cli_out_newline();
-      return true;
-    }
-
-    if ('n' == tolower(input)) {
-      cli_out_newline();
-      return false;
-    }
-
-    cli_out_error("Range Error: '%c' is not a valid input for range [Y/n]");
-  }
 }
 
 void cli_in_str(const char *msg, char *buf, size_t len) {
-  cli_out_newline();
-  cli_out_prompt("%s:", msg);
+    cli_out_newline();
+    cli_out_prompt("%s:", msg);
 
-  size_t read = 0;
-  for (; read < len; read++) {
-    char c = getchar();
+    size_t read = 0;
+    for (; read < len; read++) {
+        char c = getchar();
 
-    if (EOF == c || '\n' == c) {
-      cli_out_newline();
-      return;
+        if (EOF == c || '\n' == c) {
+            cli_out_newline();
+            return;
+        }
+
+        buf[read] = c;
     }
 
-    buf[read] = c;
-  }
-
-  cli_out_newline();
-  clear_input_stream();
+    cli_out_newline();
+    clear_input_stream();
 }
 
 size_t cli_in_dystr(const char *msg, char **dst) {
-  cli_out_newline();
-  cli_out_prompt("%s:", msg);
-  size_t ret = stream_dyreadline(stdin, dst);
-  if (0 < ret) {
     cli_out_newline();
-  }
-  return ret;
+    cli_out_prompt("%s:", msg);
+    size_t ret = stream_dyreadline(stdin, dst);
+    if (0 < ret) {
+        cli_out_newline();
+    }
+    return ret;
 }

--- a/src/common/cli/parser.c
+++ b/src/common/cli/parser.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -27,60 +27,62 @@ bool cli_parse(int         argc,
                char       *argv[],
                cli_info_t *cli_info,
                cli_exec_t *handler) {
-  if (2 > argc) {
+    if (2 > argc) {
+        return true;
+    }
+
+    // Descriptor of the command
+    cli_drt_desc_t cmd_desc;
+
+    // If no matching command is found, an
+    // error is thrown
+    if (!cli_lkup_command(argv[1], &cmd_desc)) {
+        cli_out_error("Unknown command '%s'. Try 'tarman help' for help",
+                      argv[1]);
+        return false;
+    }
+
+    *handler = cmd_desc.exec_handler;
+
+    for (int i = 2; i < argc; i++) {
+        const char *argument = argv[i];
+        const char *next     = NULL;
+        if (argc - 1 != i) {
+            next = argv[i + 1];
+        }
+
+        cli_drt_desc_t opt_desc;
+
+        // If no mathcing option was found
+        // This argument is treated as the input file
+        if (!cli_lkup_option(argument, &opt_desc)) {
+            if ('-' == argument[0]) {
+                cli_out_error(
+                    "Unrecognized option '%s'. Try 'tarman help' for help",
+                    argument);
+                return false;
+            }
+
+            if (NULL != cli_info->input) {
+                cli_out_error("Too many inputs");
+                return false;
+            }
+
+            cli_info->input = argument;
+            continue;
+        }
+
+        // Skip next CLI argument if the option required an arguments
+        // of its own
+        if (opt_desc.has_argument) {
+            i++;
+        }
+
+        // If the handler is for an option
+        if (NULL != opt_desc.handler && !opt_desc.handler(cli_info, next)) {
+            return false;
+        }
+    }
+
     return true;
-  }
-
-  // Descriptor of the command
-  cli_drt_desc_t cmd_desc;
-
-  // If no matching command is found, an
-  // error is thrown
-  if (!cli_lkup_command(argv[1], &cmd_desc)) {
-    cli_out_error("Unknown command '%s'. Try 'tarman help' for help", argv[1]);
-    return false;
-  }
-
-  *handler = cmd_desc.exec_handler;
-
-  for (int i = 2; i < argc; i++) {
-    const char *argument = argv[i];
-    const char *next     = NULL;
-    if (argc - 1 != i) {
-      next = argv[i + 1];
-    }
-
-    cli_drt_desc_t opt_desc;
-
-    // If no mathcing option was found
-    // This argument is treated as the input file
-    if (!cli_lkup_option(argument, &opt_desc)) {
-      if ('-' == argument[0]) {
-        cli_out_error("Unrecognized option '%s'. Try 'tarman help' for help",
-                      argument);
-        return false;
-      }
-
-      if (NULL != cli_info->input) {
-        cli_out_error("Too many inputs");
-        return false;
-      }
-
-      cli_info->input = argument;
-      continue;
-    }
-
-    // Skip next CLI argument if the option required an arguments
-    // of its own
-    if (opt_desc.has_argument) {
-      i++;
-    }
-
-    // If the handler is for an option
-    if (NULL != opt_desc.handler && !opt_desc.handler(cli_info, next)) {
-      return false;
-    }
-  }
-
-  return true;
 }

--- a/src/common/config.c
+++ b/src/common/config.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -27,22 +27,22 @@
 #include "tm-mem.h"
 
 static bool tokenize(char *line, const char **key, const char **value) {
-  for (size_t i = 0; line[i]; i++) {
-    char ch = line[i];
+    for (size_t i = 0; line[i]; i++) {
+        char ch = line[i];
 
-    if (' ' == ch) {
-      return false;
+        if (' ' == ch) {
+            return false;
+        }
+
+        if ('=' == ch) {
+            line[i] = 0;
+            *key    = line;
+            *value  = &line[i + 1];
+            return true;
+        }
     }
 
-    if ('=' == ch) {
-      line[i] = 0;
-      *key    = line;
-      *value  = &line[i + 1];
-      return true;
-    }
-  }
-
-  return false;
+    return false;
 }
 
 cfg_prop_match_t cfg_eval_prop(const char  *prop,
@@ -51,86 +51,86 @@ cfg_prop_match_t cfg_eval_prop(const char  *prop,
                                const char **target,
                                size_t       num_args,
                                ...) {
-  // Declared here for backwards compatibility
-  char *value_cpy = NULL;
+    // Declared here for backwards compatibility
+    char *value_cpy = NULL;
 
-  if (0 != strcmp(prop, key)) {
-    return TM_CFG_PROP_MATCH_FALSE;
-  }
-
-  if (0 == num_args) {
-    goto success;
-  }
-
-  va_list args;
-  va_start(args, num_args);
-
-  // Check the match range
-  // This is if the propertly can only have
-  // a select number of values (such as true or false)
-  for (size_t i = 0; i < num_args; i++) {
-    const char *range_elem = va_arg(args, char *);
-
-    if (0 == strcmp(value, range_elem)) {
-      va_end(args);
-      goto success;
+    if (0 != strcmp(prop, key)) {
+        return TM_CFG_PROP_MATCH_FALSE;
     }
-  }
 
-  // If the code gets here, the functions has failed
-  // This is because of the goto success;
-  va_end(args);
-  return TM_CFG_PROP_MATCH_ERR;
+    if (0 == num_args) {
+        goto success;
+    }
+
+    va_list args;
+    va_start(args, num_args);
+
+    // Check the match range
+    // This is if the propertly can only have
+    // a select number of values (such as true or false)
+    for (size_t i = 0; i < num_args; i++) {
+        const char *range_elem = va_arg(args, char *);
+
+        if (0 == strcmp(value, range_elem)) {
+            va_end(args);
+            goto success;
+        }
+    }
+
+    // If the code gets here, the functions has failed
+    // This is because of the goto success;
+    va_end(args);
+    return TM_CFG_PROP_MATCH_ERR;
 
 success:
-  value_cpy = (char *)malloc((strlen(value) + 1) * sizeof(char));
-  mem_chkoom(value_cpy);
-  strcpy(value_cpy, value);
-  *target = value_cpy;
+    value_cpy = (char *)malloc((strlen(value) + 1) * sizeof(char));
+    mem_chkoom(value_cpy);
+    strcpy(value_cpy, value);
+    *target = value_cpy;
 
-  return TM_CFG_PROP_MATCH_OK;
+    return TM_CFG_PROP_MATCH_OK;
 }
 
 cfg_prop_match_t cfg_eval_prop_matches(size_t num_args, ...) {
-  va_list args;
-  va_start(args, num_args);
+    va_list args;
+    va_start(args, num_args);
 
-  cfg_prop_match_t ret = TM_CFG_PROP_MATCH_FALSE;
+    cfg_prop_match_t ret = TM_CFG_PROP_MATCH_FALSE;
 
-  for (size_t i = 0; i < num_args; i++) {
-    cfg_prop_match_t match = va_arg(args, cfg_prop_match_t);
+    for (size_t i = 0; i < num_args; i++) {
+        cfg_prop_match_t match = va_arg(args, cfg_prop_match_t);
 
-    if (TM_CFG_PROP_MATCH_ERR == match) {
-      va_end(args);
-      return TM_CFG_PROP_MATCH_ERR;
+        if (TM_CFG_PROP_MATCH_ERR == match) {
+            va_end(args);
+            return TM_CFG_PROP_MATCH_ERR;
+        }
+
+        if (TM_CFG_PROP_MATCH_OK == match) {
+            ret = TM_CFG_PROP_MATCH_OK;
+        }
     }
 
-    if (TM_CFG_PROP_MATCH_OK == match) {
-      ret = TM_CFG_PROP_MATCH_OK;
-    }
-  }
-
-  va_end(args);
-  return ret;
+    va_end(args);
+    return ret;
 }
 
 cfg_parse_status_t
 cfg_parse(FILE *stream, cfg_translator_t translator, cfg_generic_info_t *info) {
-  char *line_buffer;
+    char *line_buffer;
 
-  while (0 != stream_dyreadline(stream, &line_buffer)) {
-    const char        *key   = NULL;
-    const char        *value = NULL;
-    cfg_parse_status_t s     = TM_CFG_PARSE_STATUS_MALFORMED;
+    while (0 != stream_dyreadline(stream, &line_buffer)) {
+        const char        *key   = NULL;
+        const char        *value = NULL;
+        cfg_parse_status_t s     = TM_CFG_PARSE_STATUS_MALFORMED;
 
-    if (!tokenize(line_buffer, &key, &value) ||
-        TM_CFG_PARSE_STATUS_OK != (s = translator(key, value, info))) {
-      mem_safe_free(line_buffer);
-      return s;
+        if (!tokenize(line_buffer, &key, &value) ||
+            TM_CFG_PARSE_STATUS_OK != (s = translator(key, value, info))) {
+            mem_safe_free(line_buffer);
+            return s;
+        }
+
+        mem_safe_free(line_buffer);
     }
 
-    mem_safe_free(line_buffer);
-  }
-
-  return TM_CFG_PARSE_STATUS_OK;
+    return TM_CFG_PARSE_STATUS_OK;
 }

--- a/src/common/download.c
+++ b/src/common/download.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -23,9 +23,9 @@
 #include "plugin/plugin.h"
 
 bool download(const char *dst, const char *url) {
-  if (plugin_exists("download-plugin")) {
-    return EXIT_SUCCESS == plugin_run("download-plugin", dst, url);
-  }
+    if (plugin_exists("download-plugin")) {
+        return EXIT_SUCCESS == plugin_run("download-plugin", dst, url);
+    }
 
-  return EXIT_SUCCESS == os_exec("curl", "-L", url, "-o", dst, NULL);
+    return EXIT_SUCCESS == os_exec("curl", "-L", url, "-o", dst, NULL);
 }

--- a/src/common/main.c
+++ b/src/common/main.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -25,16 +25,16 @@
 #include "cli/parser.h"
 
 int main(int argc, char *argv[]) {
-  cli_info_t cli_info        = {0};
-  cli_exec_t command_handler = NULL;
+    cli_info_t cli_info        = {0};
+    cli_exec_t command_handler = NULL;
 
-  if (!cli_parse(argc, argv, &cli_info, &command_handler)) {
-    return EXIT_FAILURE;
-  }
+    if (!cli_parse(argc, argv, &cli_info, &command_handler)) {
+        return EXIT_FAILURE;
+    }
 
-  if (NULL == command_handler) {
-    return cli_cmd_help(cli_info);
-  }
+    if (NULL == command_handler) {
+        return cli_cmd_help(cli_info);
+    }
 
-  return command_handler(cli_info);
+    return command_handler(cli_info);
 }

--- a/src/common/package.c
+++ b/src/common/package.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -28,174 +28,174 @@
 
 static cfg_parse_status_t
 pkg_translator(const char *key, const char *value, pkg_info_t *pkg_info) {
-  cfg_prop_match_t match = cfg_eval_prop_matches(
-      6,
-      cfg_eval_prop("URL", key, value, &pkg_info->url, 0),
-      cfg_eval_prop(
-          "FROM_REPOSITORY", key, value, &pkg_info->from_repoistory, 0),
-      cfg_eval_prop(
-          "APPLICATION_NAME", key, value, &pkg_info->application_name, 0),
-      cfg_eval_prop(
-          "EXECUTABLE_PATH", key, value, &pkg_info->executable_path, 0),
-      cfg_eval_prop(
-          "WORKING_DIRECTORY", key, value, &pkg_info->working_directory, 0),
-      cfg_eval_prop("ICON_PATH", key, value, &pkg_info->icon_path, 0));
+    cfg_prop_match_t match = cfg_eval_prop_matches(
+        6,
+        cfg_eval_prop("URL", key, value, &pkg_info->url, 0),
+        cfg_eval_prop(
+            "FROM_REPOSITORY", key, value, &pkg_info->from_repoistory, 0),
+        cfg_eval_prop(
+            "APPLICATION_NAME", key, value, &pkg_info->application_name, 0),
+        cfg_eval_prop(
+            "EXECUTABLE_PATH", key, value, &pkg_info->executable_path, 0),
+        cfg_eval_prop(
+            "WORKING_DIRECTORY", key, value, &pkg_info->working_directory, 0),
+        cfg_eval_prop("ICON_PATH", key, value, &pkg_info->icon_path, 0));
 
-  if (TM_CFG_PROP_MATCH_ERR == match) {
-    return TM_CFG_PARSE_STATUS_INVVAL;
-  }
+    if (TM_CFG_PROP_MATCH_ERR == match) {
+        return TM_CFG_PARSE_STATUS_INVVAL;
+    }
 
-  return TM_CFG_PARSE_STATUS_OK;
+    return TM_CFG_PARSE_STATUS_OK;
 }
 
 static cfg_parse_status_t
 rcp_translator(const char *key, const char *value, recipe_t *rcp) {
-  cfg_parse_status_t pkg_status = pkg_translator(key, value, &rcp->pkg_info);
+    cfg_parse_status_t pkg_status = pkg_translator(key, value, &rcp->pkg_info);
 
-  if (TM_CFG_PARSE_STATUS_OK != pkg_status) {
-    return pkg_status;
-  }
+    if (TM_CFG_PARSE_STATUS_OK != pkg_status) {
+        return pkg_status;
+    }
 
-  const char *add_to_path    = NULL;
-  const char *add_to_desktop = NULL;
-  const char *add_to_tarman  = NULL;
+    const char *add_to_path    = NULL;
+    const char *add_to_desktop = NULL;
+    const char *add_to_tarman  = NULL;
 
-  cfg_prop_match_t match = cfg_eval_prop_matches(
-      4,
-      cfg_eval_prop("PACKAGE_FORMAT", key, value, &rcp->package_format, 0),
-      cfg_eval_prop(
-          "ADD_TO_PATH", key, value, &add_to_path, 2, "true", "false"),
-      cfg_eval_prop(
-          "ADD_TO_DESKTOP", key, value, &add_to_desktop, 2, "true", "false"),
-      cfg_eval_prop(
-          "ADD_TO_TARMAN", key, value, &add_to_tarman, 2, "true", "false"));
+    cfg_prop_match_t match = cfg_eval_prop_matches(
+        4,
+        cfg_eval_prop("PACKAGE_FORMAT", key, value, &rcp->package_format, 0),
+        cfg_eval_prop(
+            "ADD_TO_PATH", key, value, &add_to_path, 2, "true", "false"),
+        cfg_eval_prop(
+            "ADD_TO_DESKTOP", key, value, &add_to_desktop, 2, "true", "false"),
+        cfg_eval_prop(
+            "ADD_TO_TARMAN", key, value, &add_to_tarman, 2, "true", "false"));
 
-  if (TM_CFG_PROP_MATCH_ERR == match) {
-    return TM_CFG_PARSE_STATUS_INVVAL;
-  }
+    if (TM_CFG_PROP_MATCH_ERR == match) {
+        return TM_CFG_PARSE_STATUS_INVVAL;
+    }
 
-  if (NULL != add_to_path && 0 == strcmp(add_to_path, "true")) {
-    rcp->add_to_path = true;
-  }
+    if (NULL != add_to_path && 0 == strcmp(add_to_path, "true")) {
+        rcp->add_to_path = true;
+    }
 
-  if (NULL != add_to_desktop && 0 == strcmp(add_to_desktop, "true")) {
-    rcp->add_to_desktop = true;
-  }
+    if (NULL != add_to_desktop && 0 == strcmp(add_to_desktop, "true")) {
+        rcp->add_to_desktop = true;
+    }
 
-  if (NULL != add_to_tarman && 0 == strcmp(add_to_tarman, "true")) {
-    rcp->add_to_tarman = true;
-  }
+    if (NULL != add_to_tarman && 0 == strcmp(add_to_tarman, "true")) {
+        rcp->add_to_tarman = true;
+    }
 
-  mem_safe_free(add_to_path);
-  mem_safe_free(add_to_desktop);
-  mem_safe_free(add_to_tarman);
-  return TM_CFG_PARSE_STATUS_OK;
+    mem_safe_free(add_to_path);
+    mem_safe_free(add_to_desktop);
+    mem_safe_free(add_to_tarman);
+    return TM_CFG_PARSE_STATUS_OK;
 }
 
 static void dump_if_set(FILE *fp, const char *key, const char *value) {
-  if (NULL != value) {
-    fprintf(fp, "%s=%s\n", key, value);
-  }
+    if (NULL != value) {
+        fprintf(fp, "%s=%s\n", key, value);
+    }
 }
 
 static void dump_bool(FILE *fp, const char *key, bool value) {
-  if (value) {
-    fprintf(fp, "%s=true\n", key);
-  } else {
-    fprintf(fp, "%s=false\n", key);
-  }
+    if (value) {
+        fprintf(fp, "%s=true\n", key);
+    } else {
+        fprintf(fp, "%s=false\n", key);
+    }
 }
 
 cfg_parse_status_t pkg_parse_ftmpkg(pkg_info_t *pkg_info, FILE *pkg_file) {
-  if (NULL == pkg_file) {
-    return TM_CFG_PARSE_STATUS_NOFILE;
-  }
+    if (NULL == pkg_file) {
+        return TM_CFG_PARSE_STATUS_NOFILE;
+    }
 
-  cfg_parse_status_t ret =
-      cfg_parse(pkg_file, (cfg_translator_t)pkg_translator, pkg_info);
+    cfg_parse_status_t ret =
+        cfg_parse(pkg_file, (cfg_translator_t)pkg_translator, pkg_info);
 
-  if (TM_CFG_PARSE_STATUS_OK != ret) {
-    pkg_free_pkg(*pkg_info);
-  }
+    if (TM_CFG_PARSE_STATUS_OK != ret) {
+        pkg_free_pkg(*pkg_info);
+    }
 
-  return ret;
+    return ret;
 }
 
 cfg_parse_status_t pkg_parse_tmpkg(pkg_info_t *pkg_info,
                                    const char *pkg_file_path) {
-  FILE              *fp  = fopen(pkg_file_path, "r");
-  cfg_parse_status_t ret = pkg_parse_ftmpkg(pkg_info, fp);
+    FILE              *fp  = fopen(pkg_file_path, "r");
+    cfg_parse_status_t ret = pkg_parse_ftmpkg(pkg_info, fp);
 
-  if (NULL != fp) {
-    fclose(fp);
-  }
+    if (NULL != fp) {
+        fclose(fp);
+    }
 
-  return ret;
+    return ret;
 }
 
 cfg_parse_status_t pkg_parse_ftmrcp(recipe_t *rcp, FILE *rcp_file) {
-  if (NULL == rcp_file) {
-    return TM_CFG_PARSE_STATUS_NOFILE;
-  }
+    if (NULL == rcp_file) {
+        return TM_CFG_PARSE_STATUS_NOFILE;
+    }
 
-  cfg_parse_status_t ret =
-      cfg_parse(rcp_file, (cfg_translator_t)rcp_translator, rcp);
+    cfg_parse_status_t ret =
+        cfg_parse(rcp_file, (cfg_translator_t)rcp_translator, rcp);
 
-  if (TM_CFG_PARSE_STATUS_OK != ret) {
-    pkg_free_rcp(*rcp);
-  }
+    if (TM_CFG_PARSE_STATUS_OK != ret) {
+        pkg_free_rcp(*rcp);
+    }
 
-  return ret;
+    return ret;
 }
 
 cfg_parse_status_t pkg_parse_tmrcp(recipe_t *rcp, const char *rcp_file_path) {
-  FILE              *fp  = fopen(rcp_file_path, "r");
-  cfg_parse_status_t ret = pkg_parse_ftmrcp(rcp, fp);
+    FILE              *fp  = fopen(rcp_file_path, "r");
+    cfg_parse_status_t ret = pkg_parse_ftmrcp(rcp, fp);
 
-  if (NULL != fp) {
-    fclose(fp);
-  }
+    if (NULL != fp) {
+        fclose(fp);
+    }
 
-  return ret;
+    return ret;
 }
 
 bool pkg_dump_frcp(FILE *fp, recipe_t recipe) {
-  dump_if_set(fp, "URL", recipe.pkg_info.url);
-  dump_if_set(fp, "FROM_REPOSITORY", recipe.pkg_info.from_repoistory);
-  dump_if_set(fp, "APPLICATION_NAME", recipe.pkg_info.application_name);
-  dump_if_set(fp, "EXECUTABLE_PATH", recipe.pkg_info.executable_path);
-  dump_if_set(fp, "WORKING_DIRECTORY", recipe.pkg_info.working_directory);
-  dump_if_set(fp, "ICON_PATH", recipe.pkg_info.icon_path);
-  dump_if_set(fp, "PACKAGE_FORMAT", recipe.package_format);
-  dump_bool(fp, "ADD_TO_PATH", recipe.add_to_path);
-  dump_bool(fp, "ADD_TO_DESKTOP", recipe.add_to_desktop);
-  dump_bool(fp, "ADD_TO_TARMAN", recipe.add_to_tarman);
+    dump_if_set(fp, "URL", recipe.pkg_info.url);
+    dump_if_set(fp, "FROM_REPOSITORY", recipe.pkg_info.from_repoistory);
+    dump_if_set(fp, "APPLICATION_NAME", recipe.pkg_info.application_name);
+    dump_if_set(fp, "EXECUTABLE_PATH", recipe.pkg_info.executable_path);
+    dump_if_set(fp, "WORKING_DIRECTORY", recipe.pkg_info.working_directory);
+    dump_if_set(fp, "ICON_PATH", recipe.pkg_info.icon_path);
+    dump_if_set(fp, "PACKAGE_FORMAT", recipe.package_format);
+    dump_bool(fp, "ADD_TO_PATH", recipe.add_to_path);
+    dump_bool(fp, "ADD_TO_DESKTOP", recipe.add_to_desktop);
+    dump_bool(fp, "ADD_TO_TARMAN", recipe.add_to_tarman);
 
-  return true;
+    return true;
 }
 
 bool pkg_dump_rcp(const char *file_path, recipe_t recipe) {
-  FILE *fp = fopen(file_path, "w");
+    FILE *fp = fopen(file_path, "w");
 
-  if (NULL == fp) {
-    return false;
-  }
+    if (NULL == fp) {
+        return false;
+    }
 
-  bool ret = pkg_dump_frcp(fp, recipe);
-  fclose(fp);
-  return ret;
+    bool ret = pkg_dump_frcp(fp, recipe);
+    fclose(fp);
+    return ret;
 }
 
 void pkg_free_pkg(pkg_info_t pkg_info) {
-  mem_safe_free(pkg_info.url);
-  mem_safe_free(pkg_info.from_repoistory);
-  mem_safe_free(pkg_info.executable_path);
-  mem_safe_free(pkg_info.application_name);
-  mem_safe_free(pkg_info.working_directory);
-  mem_safe_free(pkg_info.icon_path);
+    mem_safe_free(pkg_info.url);
+    mem_safe_free(pkg_info.from_repoistory);
+    mem_safe_free(pkg_info.executable_path);
+    mem_safe_free(pkg_info.application_name);
+    mem_safe_free(pkg_info.working_directory);
+    mem_safe_free(pkg_info.icon_path);
 }
 
 void pkg_free_rcp(recipe_t recipe) {
-  pkg_free_pkg(recipe.pkg_info);
-  mem_safe_free(recipe.package_format);
+    pkg_free_pkg(recipe.pkg_info);
+    mem_safe_free(recipe.package_format);
 }

--- a/src/common/plugin/plugin.c
+++ b/src/common/plugin/plugin.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -30,25 +30,25 @@
 #define SPACE  1
 
 bool plugin_exists(const char *plugin) {
-  const char *plugin_path = NULL;
-  os_fs_tm_dyplugin(&plugin_path, plugin);
+    const char *plugin_path = NULL;
+    os_fs_tm_dyplugin(&plugin_path, plugin);
 
-  fs_filetype_t      ftype;
-  fs_fileop_status_t op_status = os_fs_file_gettype(&ftype, plugin_path);
+    fs_filetype_t      ftype;
+    fs_fileop_status_t op_status = os_fs_file_gettype(&ftype, plugin_path);
 
-  mem_safe_free(plugin_path);
-  return TM_FS_FILETYPE_EXEC == ftype && TM_FS_FILEOP_STATUS_OK == op_status;
+    mem_safe_free(plugin_path);
+    return TM_FS_FILETYPE_EXEC == ftype && TM_FS_FILEOP_STATUS_OK == op_status;
 }
 
 int plugin_run(const char *plugin, const char *dst, const char *src) {
-  const char *plugin_path   = NULL;
-  const char *plugconf_path = NULL;
-  os_fs_tm_dyplugin(&plugin_path, plugin);
-  os_fs_tm_dyplugconf(&plugconf_path, plugin);
+    const char *plugin_path   = NULL;
+    const char *plugconf_path = NULL;
+    os_fs_tm_dyplugin(&plugin_path, plugin);
+    os_fs_tm_dyplugconf(&plugconf_path, plugin);
 
-  int ret = os_exec(plugin_path, src, dst, plugconf_path, NULL);
+    int ret = os_exec(plugin_path, src, dst, plugconf_path, NULL);
 
-  mem_safe_free(plugin_path);
-  mem_safe_free(plugconf_path);
-  return ret;
+    mem_safe_free(plugin_path);
+    mem_safe_free(plugconf_path);
+    return ret;
 }

--- a/src/common/stream.c
+++ b/src/common/stream.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -23,41 +23,41 @@
 #include "tm-mem.h"
 
 size_t stream_dyreadline(FILE *stream, char **dst) {
-  size_t len        = 128;
-  char  *buf        = NULL;
-  size_t i          = 0;
-  char   ch         = 0;
-  bool   found_chrs = false;
+    size_t len        = 128;
+    char  *buf        = NULL;
+    size_t i          = 0;
+    char   ch         = 0;
+    bool   found_chrs = false;
 
-  while (EOF != (ch = fgetc(stream)) && '\n' != ch) {
-    if ('\r' == ch) {
-      continue;
+    while (EOF != (ch = fgetc(stream)) && '\n' != ch) {
+        if ('\r' == ch) {
+            continue;
+        }
+
+        if (!found_chrs && ' ' == ch) {
+            continue;
+        }
+
+        if (NULL == buf) {
+            buf = (char *)malloc(len * sizeof(char));
+            mem_chkoom(buf);
+        }
+
+        if (len - 1 == i) {
+            len *= 2;
+            buf = realloc(buf, len * sizeof(char));
+            mem_chkoom(buf);
+        }
+
+        found_chrs = true;
+        buf[i]     = ch;
+        i++;
     }
 
-    if (!found_chrs && ' ' == ch) {
-      continue;
+    if (NULL != buf) {
+        buf[i] = 0;
+        *dst   = buf;
     }
 
-    if (NULL == buf) {
-      buf = (char *)malloc(len * sizeof(char));
-      mem_chkoom(buf);
-    }
-
-    if (len - 1 == i) {
-      len *= 2;
-      buf = realloc(buf, len * sizeof(char));
-      mem_chkoom(buf);
-    }
-
-    found_chrs = true;
-    buf[i]     = ch;
-    i++;
-  }
-
-  if (NULL != buf) {
-    buf[i] = 0;
-    *dst   = buf;
-  }
-
-  return i;
+    return i;
 }

--- a/src/common/tm-mem.c
+++ b/src/common/tm-mem.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -21,19 +21,19 @@
 #include "cli/output.h"
 
 void mem_safe_free(void *ptr) {
-  if (NULL != ptr) {
-    free(ptr);
-  }
+    if (NULL != ptr) {
+        free(ptr);
+    }
 }
 
 void mem_oom(void) {
-  cli_out_error("Unable to allocate memory, probably ran out of memory. "
-                "Exiting now");
-  exit(EXIT_FAILURE);
+    cli_out_error("Unable to allocate memory, probably ran out of memory. "
+                  "Exiting now");
+    exit(EXIT_FAILURE);
 }
 
 void mem_chkoom(void *ptr) {
-  if (NULL == ptr) {
-    mem_oom();
-  }
+    if (NULL == ptr) {
+        mem_oom();
+    }
 }

--- a/src/common/util/misc.c
+++ b/src/common/util/misc.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -27,26 +27,26 @@ size_t util_misc_dyfile(char      **dst,
                         const char *base_path,
                         const char *filename,
                         const char *filetype) {
-  size_t bufsz = strlen(filename) + 1 + strlen(filetype) + 1;
-  char  *fname = (char *)malloc(bufsz * sizeof(char));
-  mem_chkoom(fname);
-  snprintf(fname, bufsz, "%s.%s", filename, filetype);
+    size_t bufsz = strlen(filename) + 1 + strlen(filetype) + 1;
+    char  *fname = (char *)malloc(bufsz * sizeof(char));
+    mem_chkoom(fname);
+    snprintf(fname, bufsz, "%s.%s", filename, filetype);
 
-  size_t ret = os_fs_path_dyconcat(dst, 2, base_path, fname);
+    size_t ret = os_fs_path_dyconcat(dst, 2, base_path, fname);
 
-  mem_safe_free(fname);
-  return ret;
+    mem_safe_free(fname);
+    return ret;
 }
 
 size_t
 util_misc_dytmpfile(char **dst, const char *filename, const char *filetype) {
-  size_t bufsz = strlen(filename) + 1 + strlen(filetype) + 1;
-  char  *fname = (char *)malloc(bufsz * sizeof(char));
-  mem_chkoom(fname);
-  snprintf(fname, bufsz, "%s.%s", filename, filetype);
+    size_t bufsz = strlen(filename) + 1 + strlen(filetype) + 1;
+    char  *fname = (char *)malloc(bufsz * sizeof(char));
+    mem_chkoom(fname);
+    snprintf(fname, bufsz, "%s.%s", filename, filetype);
 
-  os_fs_tm_dycached(dst, fname);
-  mem_safe_free(fname);
+    os_fs_tm_dycached(dst, fname);
+    mem_safe_free(fname);
 
-  return bufsz - 1;
+    return bufsz - 1;
 }

--- a/src/common/util/pkg.c
+++ b/src/common/util/pkg.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -30,12 +30,12 @@
 #include "util/pkg.h"
 
 static const char *override_if_dst_unset(const char *dst, const char *src) {
-  if (NULL == dst || 0 == dst[0]) {
-    return src;
-  }
+    if (NULL == dst || 0 == dst[0]) {
+        return src;
+    }
 
-  mem_safe_free(src);
-  return dst;
+    mem_safe_free(src);
+    return dst;
 }
 
 bool util_pkg_fetch_archive(char      **dst_file,
@@ -43,83 +43,85 @@ bool util_pkg_fetch_archive(char      **dst_file,
                             const char *pkg_fmt,
                             const char *url,
                             bool        log) {
-  util_misc_dytmpfile(dst_file, pkg_name, pkg_fmt);
+    util_misc_dytmpfile(dst_file, pkg_name, pkg_fmt);
 
-  if (log) {
-    cli_out_progress("Downloading package from '%s' to '%s'", url, *dst_file);
-  }
-
-  if (!download(*dst_file, url)) {
     if (log) {
-      cli_out_error("Unable to download package");
+        cli_out_progress(
+            "Downloading package from '%s' to '%s'", url, *dst_file);
     }
-    return false;
-  }
 
-  return true;
+    if (!download(*dst_file, url)) {
+        if (log) {
+            cli_out_error("Unable to download package");
+        }
+        return false;
+    }
+
+    return true;
 }
 
 bool util_pkg_create_directory_from_path(const char *path, bool log, bool in) {
-  if (log) {
-    cli_out_progress("Creating package in '%s'", path);
-  }
-
-  // Repeat a maximum of two times
-  for (size_t i = 0; i < 2; i++) {
-    fs_dirop_status_t pkgdir_status = os_fs_mkdir(path);
-
-    switch (pkgdir_status) {
-    case TM_FS_DIROP_STATUS_EXIST:
-      if (in) {
-        return cli_in_bool(
-            "This pacakge is already installed, proceed with clean install?");
-      }
-      if (TM_FS_DIROP_STATUS_OK != os_fs_dir_rm(path)) {
-        if (log) {
-          cli_out_error("Unable to remove pre-existing package directory '%s'",
-                        path);
-        }
-        return false;
-      }
-      break;
-
-    case TM_FS_DIROP_STATUS_OK:
-      return true;
-
-    default:
-      goto fail;
+    if (log) {
+        cli_out_progress("Creating package in '%s'", path);
     }
-  }
+
+    // Repeat a maximum of two times
+    for (size_t i = 0; i < 2; i++) {
+        fs_dirop_status_t pkgdir_status = os_fs_mkdir(path);
+
+        switch (pkgdir_status) {
+        case TM_FS_DIROP_STATUS_EXIST:
+            if (in) {
+                return cli_in_bool("This pacakge is already installed, proceed "
+                                   "with clean install?");
+            }
+            if (TM_FS_DIROP_STATUS_OK != os_fs_dir_rm(path)) {
+                if (log) {
+                    cli_out_error(
+                        "Unable to remove pre-existing package directory '%s'",
+                        path);
+                }
+                return false;
+            }
+            break;
+
+        case TM_FS_DIROP_STATUS_OK:
+            return true;
+
+        default:
+            goto fail;
+        }
+    }
 
 fail:
-  if (log) {
-    cli_out_error("Unable to create directory in '%s'", path);
-  }
+    if (log) {
+        cli_out_error("Unable to create directory in '%s'", path);
+    }
 
-  return false;
+    return false;
 }
 
 bool util_pkg_create_directory(char      **path,
                                const char *pkg_name,
                                bool        log,
                                bool        in) {
-  os_fs_tm_dypkg(path, pkg_name);
-  return util_pkg_create_directory_from_path(*path, log, in);
+    os_fs_tm_dypkg(path, pkg_name);
+    return util_pkg_create_directory_from_path(*path, log, in);
 }
 
 bool util_pkg_add_to_path(const char *exec_full_path, bool log) {
-  if (log) {
-    cli_out_progress("Adding executable '%s' to PATH", exec_full_path);
-  }
-
-  if (!os_env_path_add(exec_full_path)) {
     if (log) {
-      cli_out_warning("Could not add executable to PATH");
+        cli_out_progress("Adding executable '%s' to PATH", exec_full_path);
     }
-    return false;
-  }
 
-  return true;
+    if (!os_env_path_add(exec_full_path)) {
+        if (log) {
+            cli_out_warning("Could not add executable to PATH");
+        }
+        return false;
+    }
+
+    return true;
 }
 
 bool util_pkg_add_to_desktop(const char *pkg_path,
@@ -128,106 +130,107 @@ bool util_pkg_add_to_desktop(const char *pkg_path,
                              const char *wrk_dir,
                              const char *icon,
                              bool        log) {
-  bool ret = true;
-  cli_out_progress("Adding app '%s' to installed apps", app_name);
+    bool ret = true;
+    cli_out_progress("Adding app '%s' to installed apps", app_name);
 
-  const char *icon_full_path = NULL;
-  const char *wrk_full_path  = NULL;
+    const char *icon_full_path = NULL;
+    const char *wrk_full_path  = NULL;
 
-  if (NULL != icon) {
-    os_fs_path_dyconcat((char **)&icon_full_path, 2, pkg_path, icon);
-  } else if (log) {
-    cli_out_warning("Application has no icon");
-  }
-
-  if (NULL != wrk_dir) {
-    os_fs_path_dyconcat((char **)&wrk_full_path, 2, pkg_path, wrk_dir);
-  } else if (log) {
-    cli_out_warning("Application has no explicit working directory");
-  }
-
-  if (!os_env_desktop_add(
-          app_name, exec_full_path, icon_full_path, wrk_full_path)) {
-    if (log) {
-      cli_out_warning("Unable to add app to system applications");
+    if (NULL != icon) {
+        os_fs_path_dyconcat((char **)&icon_full_path, 2, pkg_path, icon);
+    } else if (log) {
+        cli_out_warning("Application has no icon");
     }
-    ret = false;
-  }
 
-  mem_safe_free(icon_full_path);
-  mem_safe_free(wrk_full_path);
-  return ret;
+    if (NULL != wrk_dir) {
+        os_fs_path_dyconcat((char **)&wrk_full_path, 2, pkg_path, wrk_dir);
+    } else if (log) {
+        cli_out_warning("Application has no explicit working directory");
+    }
+
+    if (!os_env_desktop_add(
+            app_name, exec_full_path, icon_full_path, wrk_full_path)) {
+        if (log) {
+            cli_out_warning("Unable to add app to system applications");
+        }
+        ret = false;
+    }
+
+    mem_safe_free(icon_full_path);
+    mem_safe_free(wrk_full_path);
+    return ret;
 }
 
 bool util_pkg_parse_config(pkg_info_t *pkg,
                            char      **cfg_path,
                            const char *pkg_path,
                            bool        log) {
-  os_fs_path_dyconcat(cfg_path, 2, pkg_path, "package.tarman");
-  cfg_parse_status_t status = pkg_parse_tmpkg(pkg, *cfg_path);
+    os_fs_path_dyconcat(cfg_path, 2, pkg_path, "package.tarman");
+    cfg_parse_status_t status = pkg_parse_tmpkg(pkg, *cfg_path);
 
-  switch (status) {
-  case TM_CFG_PARSE_STATUS_NOFILE:
-    if (log) {
-      cli_out_warning("Package configuration file '%s' does not exist",
-                      cfg_path);
+    switch (status) {
+    case TM_CFG_PARSE_STATUS_NOFILE:
+        if (log) {
+            cli_out_warning("Package configuration file '%s' does not exist",
+                            *cfg_path);
+        }
+        return false;
+
+    case TM_CFG_PARSE_STATUS_INVVAL:
+    case TM_CFG_PARSE_STATUS_MALFORMED:
+        if (log) {
+            cli_out_warning(
+                "Ignoring malformed package configuration file at '%s'",
+                *cfg_path);
+        }
+        return false;
+
+    case TM_CFG_PARSE_STATUS_ERR:
+    case TM_CFG_PARSE_STATUS_PERM:
+        if (log) {
+            cli_out_error(
+                "Unable to read contents of package configuration file at '%s'",
+                *cfg_path);
+        }
+        return false;
+
+    default:
+        break;
     }
-    return false;
 
-  case TM_CFG_PARSE_STATUS_INVVAL:
-  case TM_CFG_PARSE_STATUS_MALFORMED:
-    if (log) {
-      cli_out_warning("Ignoring malformed package configuration file at '%s'",
-                      cfg_path);
-    }
-    return false;
-
-  case TM_CFG_PARSE_STATUS_ERR:
-  case TM_CFG_PARSE_STATUS_PERM:
-    if (log) {
-      cli_out_error(
-          "Unable to read contents of package configuration file at '%s'",
-          cfg_path);
-    }
-    return false;
-
-  default:
-    break;
-  }
-
-  return true;
+    return true;
 }
 
 bool util_pkg_load_config(pkg_info_t *pkg, const char *pkg_path, bool log) {
-  pkg_info_t tmpkg_file_data = {0};
-  char      *tmpkg_file_path = NULL;
-  bool       ret             = false;
+    pkg_info_t tmpkg_file_data = {0};
+    char      *tmpkg_file_path = NULL;
+    bool       ret             = false;
 
-  if (!util_pkg_parse_config(
-          &tmpkg_file_data, &tmpkg_file_path, pkg_path, log)) {
-    goto cleanup;
-  }
+    if (!util_pkg_parse_config(
+            &tmpkg_file_data, &tmpkg_file_path, pkg_path, log)) {
+        goto cleanup;
+    }
 
-  if (log) {
-    cli_out_progress("Using package configuration file at '%s'",
-                     tmpkg_file_path);
-  }
+    if (log) {
+        cli_out_progress("Using package configuration file at '%s'",
+                         tmpkg_file_path);
+    }
 
-  pkg->url              = override_if_dst_unset(pkg->url, tmpkg_file_data.url);
-  pkg->application_name = override_if_dst_unset(
-      pkg->application_name, tmpkg_file_data.application_name);
-  pkg->executable_path   = override_if_dst_unset(pkg->executable_path,
-                                               tmpkg_file_data.executable_path);
-  pkg->working_directory = override_if_dst_unset(
-      pkg->working_directory, tmpkg_file_data.working_directory);
-  pkg->icon_path =
-      override_if_dst_unset(pkg->icon_path, tmpkg_file_data.icon_path);
+    pkg->url = override_if_dst_unset(pkg->url, tmpkg_file_data.url);
+    pkg->application_name = override_if_dst_unset(
+        pkg->application_name, tmpkg_file_data.application_name);
+    pkg->executable_path = override_if_dst_unset(
+        pkg->executable_path, tmpkg_file_data.executable_path);
+    pkg->working_directory = override_if_dst_unset(
+        pkg->working_directory, tmpkg_file_data.working_directory);
+    pkg->icon_path =
+        override_if_dst_unset(pkg->icon_path, tmpkg_file_data.icon_path);
 
-  ret = true;
+    ret = true;
 
 cleanup:
-  mem_safe_free(tmpkg_file_path);
-  return ret;
+    mem_safe_free(tmpkg_file_path);
+    return ret;
 }
 
 bool util_pkg_parse_recipe(recipe_t   *recipe,
@@ -235,79 +238,81 @@ bool util_pkg_parse_recipe(recipe_t   *recipe,
                            const char *repo,
                            const char *rcp_name,
                            bool        log) {
-  os_fs_tm_dyrecipe(rcp_path, repo, rcp_name);
+    os_fs_tm_dyrecipe(rcp_path, repo, rcp_name);
 
-  if (log) {
-    cli_out_progress("Using recipe file '%s'", *rcp_path);
-  }
-
-  cfg_parse_status_t status = pkg_parse_tmrcp(recipe, *rcp_path);
-
-  switch (status) {
-  case TM_CFG_PARSE_STATUS_INVVAL:
-  case TM_CFG_PARSE_STATUS_MALFORMED:
     if (log) {
-      cli_out_error(
-          "Recipe file for package '%s' in repository '%s' is malformed",
-          rcp_name,
-          repo);
+        cli_out_progress("Using recipe file '%s'", *rcp_path);
     }
-    return false;
 
-  case TM_CFG_PARSE_STATUS_ERR:
-  case TM_CFG_PARSE_STATUS_PERM:
-    if (log) {
-      cli_out_error("Unable to read contents of recipe file '%s'", *rcp_path);
+    cfg_parse_status_t status = pkg_parse_tmrcp(recipe, *rcp_path);
+
+    switch (status) {
+    case TM_CFG_PARSE_STATUS_INVVAL:
+    case TM_CFG_PARSE_STATUS_MALFORMED:
+        if (log) {
+            cli_out_error(
+                "Recipe file for package '%s' in repository '%s' is malformed",
+                rcp_name,
+                repo);
+        }
+        return false;
+
+    case TM_CFG_PARSE_STATUS_ERR:
+    case TM_CFG_PARSE_STATUS_PERM:
+        if (log) {
+            cli_out_error("Unable to read contents of recipe file '%s'",
+                          *rcp_path);
+        }
+        return false;
+
+    case TM_CFG_PARSE_STATUS_NOFILE:
+        if (log) {
+            cli_out_error("Cannot open recipe file '%s', no such file",
+                          *rcp_path);
+        }
+        return false;
+
+    default:
+        break;
     }
-    return false;
 
-  case TM_CFG_PARSE_STATUS_NOFILE:
-    if (log) {
-      cli_out_error("Cannot open recipe file '%s', no such file", *rcp_path);
-    }
-    return false;
-
-  default:
-    break;
-  }
-
-  return true;
+    return true;
 }
 
 bool util_pkg_load_recipe(recipe_t   *recipe,
                           const char *repo,
                           const char *rcp_name,
                           bool        log) {
-  bool     ret           = false;
-  recipe_t rcp_file_data = {0};
-  char    *rcp_file_path = NULL;
+    bool     ret           = false;
+    recipe_t rcp_file_data = {0};
+    char    *rcp_file_path = NULL;
 
-  if (!util_pkg_parse_recipe(
-          &rcp_file_data, &rcp_file_path, repo, rcp_name, log)) {
-    goto cleanup;
-  }
+    if (!util_pkg_parse_recipe(
+            &rcp_file_data, &rcp_file_path, repo, rcp_name, log)) {
+        goto cleanup;
+    }
 
-  pkg_info_t *pkg = &recipe->pkg_info;
+    pkg_info_t *pkg = &recipe->pkg_info;
 
-  pkg->url = override_if_dst_unset(pkg->url, rcp_file_data.pkg_info.url);
-  pkg->application_name = override_if_dst_unset(
-      pkg->application_name, rcp_file_data.pkg_info.application_name);
-  pkg->executable_path = override_if_dst_unset(
-      pkg->executable_path, rcp_file_data.pkg_info.executable_path);
-  pkg->working_directory = override_if_dst_unset(
-      pkg->working_directory, rcp_file_data.pkg_info.working_directory);
-  pkg->icon_path =
-      override_if_dst_unset(pkg->icon_path, rcp_file_data.pkg_info.icon_path);
-  recipe->package_format = override_if_dst_unset(recipe->package_format,
-                                                 rcp_file_data.package_format);
+    pkg->url = override_if_dst_unset(pkg->url, rcp_file_data.pkg_info.url);
+    pkg->application_name = override_if_dst_unset(
+        pkg->application_name, rcp_file_data.pkg_info.application_name);
+    pkg->executable_path = override_if_dst_unset(
+        pkg->executable_path, rcp_file_data.pkg_info.executable_path);
+    pkg->working_directory = override_if_dst_unset(
+        pkg->working_directory, rcp_file_data.pkg_info.working_directory);
+    pkg->icon_path =
+        override_if_dst_unset(pkg->icon_path, rcp_file_data.pkg_info.icon_path);
+    recipe->package_format = override_if_dst_unset(
+        recipe->package_format, rcp_file_data.package_format);
 
-  recipe->add_to_path    = rcp_file_data.add_to_path;
-  recipe->add_to_desktop = rcp_file_data.add_to_desktop;
-  recipe->add_to_tarman  = rcp_file_data.add_to_tarman;
+    recipe->add_to_path    = rcp_file_data.add_to_path;
+    recipe->add_to_desktop = rcp_file_data.add_to_desktop;
+    recipe->add_to_tarman  = rcp_file_data.add_to_tarman;
 
-  ret = true;
+    ret = true;
 
 cleanup:
-  mem_safe_free(rcp_file_path);
-  return ret;
+    mem_safe_free(rcp_file_path);
+    return ret;
 }

--- a/src/os-common/no-optional/console.c
+++ b/src/os-common/no-optional/console.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -21,9 +21,9 @@
 #include "os/no-optional/console.h"
 
 csz_t noopt_console_get_sz(void) {
-  return (csz_t){.rows = 40, .columns = 80};
+    return (csz_t){.rows = 40, .columns = 80};
 }
 
 void noopt_console_set_color(color_t color, bool bold) {
-  // Do nothing
+    // Do nothing
 }

--- a/src/os-common/posix/console.c
+++ b/src/os-common/posix/console.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -29,49 +29,49 @@
 #include "os/console.h"
 
 csz_t posix_console_get_sz(void) {
-  struct winsize size;
-  ioctl(STDOUT_FILENO, TIOCGWINSZ, &size);
-  return (csz_t){.rows = size.ws_row, .columns = size.ws_col};
+    struct winsize size;
+    ioctl(STDOUT_FILENO, TIOCGWINSZ, &size);
+    return (csz_t){.rows = size.ws_row, .columns = size.ws_col};
 }
 
 void posix_console_set_color(color_t color, bool bold) {
-  if (!isatty(fileno(stdout))) {
-    return;
-  }
+    if (!isatty(fileno(stdout))) {
+        return;
+    }
 
-  int ansi_color = -1;
+    int ansi_color = -1;
 
-  switch (color) {
-  case TM_COLOR_RED:
-    ansi_color = 31;
-    break;
-  case TM_COLOR_GREEN:
-    ansi_color = 32;
-    break;
-  case TM_COLOR_YELLOW:
-    ansi_color = 33;
-    break;
-  case TM_COLOR_MAGENTA:
-    ansi_color = 35;
-    break;
-  case TM_COLOR_CYAN:
-    ansi_color = 36;
-    break;
-  case TM_COLOR_TEXT:
-    ansi_color = 39;
-    break;
-  case TM_COLOR_RESET:
-    printf("\033[m");
-    return;
+    switch (color) {
+    case TM_COLOR_RED:
+        ansi_color = 31;
+        break;
+    case TM_COLOR_GREEN:
+        ansi_color = 32;
+        break;
+    case TM_COLOR_YELLOW:
+        ansi_color = 33;
+        break;
+    case TM_COLOR_MAGENTA:
+        ansi_color = 35;
+        break;
+    case TM_COLOR_CYAN:
+        ansi_color = 36;
+        break;
+    case TM_COLOR_TEXT:
+        ansi_color = 39;
+        break;
+    case TM_COLOR_RESET:
+        printf("\033[m");
+        return;
 
-  default:
-    return;
-  }
+    default:
+        return;
+    }
 
-  if (!bold) {
-    printf("\033[0;%dm", ansi_color);
-    return;
-  }
+    if (!bold) {
+        printf("\033[0;%dm", ansi_color);
+        return;
+    }
 
-  printf("\033[1;%dm", ansi_color);
+    printf("\033[1;%dm", ansi_color);
 }

--- a/src/os-common/posix/env.c
+++ b/src/os-common/posix/env.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -30,52 +30,52 @@
 #include "tm-mem.h"
 
 static const char *get_name(const char *path) {
-  size_t len      = strlen(path);
-  size_t last_idx = len - 2;
+    size_t len      = strlen(path);
+    size_t last_idx = len - 2;
 
-  for (size_t i = last_idx; i > 0; i--) {
-    if ('/' == path[i]) {
-      return &path[i + 1];
+    for (size_t i = last_idx; i > 0; i--) {
+        if ('/' == path[i]) {
+            return &path[i + 1];
+        }
     }
-  }
 
-  return path;
+    return path;
 }
 
 bool posix_env_path_add(const char *executable) {
-  if (NULL == executable) {
-    return false;
-  }
+    if (NULL == executable) {
+        return false;
+    }
 
-  const char *path_item = NULL;
-  const char *exec_name = get_name(executable);
+    const char *path_item = NULL;
+    const char *exec_name = get_name(executable);
 
-  if (0 == posix_fs_tm_dyexecpath(&path_item, exec_name)) {
-    return false;
-  }
+    if (0 == posix_fs_tm_dyexecpath(&path_item, exec_name)) {
+        return false;
+    }
 
-  if (0 != symlink(executable, path_item)) {
+    if (0 != symlink(executable, path_item)) {
+        mem_safe_free(path_item);
+        return false;
+    }
+
     mem_safe_free(path_item);
-    return false;
-  }
-
-  mem_safe_free(path_item);
-  return true;
+    return true;
 }
 
 bool posix_env_path_rm(const char *executable) {
-  if (NULL == executable) {
-    return false;
-  }
+    if (NULL == executable) {
+        return false;
+    }
 
-  const char *path_item = NULL;
-  const char *exec_name = get_name(executable);
+    const char *path_item = NULL;
+    const char *exec_name = get_name(executable);
 
-  if (0 == posix_fs_tm_dyexecpath(&path_item, exec_name)) {
-    return false;
-  }
+    if (0 == posix_fs_tm_dyexecpath(&path_item, exec_name)) {
+        return false;
+    }
 
-  fs_fileop_status_t rm_status = os_fs_file_rm(path_item);
-  mem_safe_free(path_item);
-  return TM_FS_FILEOP_STATUS_OK == rm_status;
+    fs_fileop_status_t rm_status = os_fs_file_rm(path_item);
+    mem_safe_free(path_item);
+    return TM_FS_FILEOP_STATUS_OK == rm_status;
 }

--- a/src/os-common/posix/exec.c
+++ b/src/os-common/posix/exec.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -31,49 +31,49 @@
 #include "tm-mem.h"
 
 static size_t count_args(va_list args) {
-  va_list copy;
-  va_copy(copy, args);
-  size_t count = 0;
-  for (; NULL != va_arg(copy, char *); count++)
-    ;
-  va_end(copy);
-  return count + 1 + 1; // Add 1 for NULL and for the program
+    va_list copy;
+    va_copy(copy, args);
+    size_t count = 0;
+    for (; NULL != va_arg(copy, char *); count++)
+        ;
+    va_end(copy);
+    return count + 1 + 1; // Add 1 for NULL and for the program
 }
 
 int posix_vexec(const char *executable, va_list args) {
-  size_t       arg_count = count_args(args);
-  const char **argv      = (const char **)malloc(arg_count * sizeof(char *));
-  mem_chkoom(argv);
+    size_t       arg_count = count_args(args);
+    const char **argv      = (const char **)malloc(arg_count * sizeof(char *));
+    mem_chkoom(argv);
 
-  argv[0] = executable;
-  for (size_t i = 1; i < arg_count; i++) {
-    char *arg = va_arg(args, char *);
-    argv[i]   = arg;
-  }
+    argv[0] = executable;
+    for (size_t i = 1; i < arg_count; i++) {
+        char *arg = va_arg(args, char *);
+        argv[i]   = arg;
+    }
 
-  pid_t pid = fork();
+    pid_t pid = fork();
 
-  if (0 > pid) {
-    return EXIT_FAILURE;
-  }
+    if (0 > pid) {
+        return EXIT_FAILURE;
+    }
 
-  // When fork gets here it means
-  // that this is the child process
-  if (0 == pid) {
-    fclose(stdout);
-    fclose(stderr);
-    fclose(stdin);
-    return execvp(executable, (char **)argv);
-  }
+    // When fork gets here it means
+    // that this is the child process
+    if (0 == pid) {
+        fclose(stdout);
+        fclose(stderr);
+        fclose(stdin);
+        return execvp(executable, (char **)argv);
+    }
 
-  int status;
-  int ret = EXIT_FAILURE;
-  waitpid(pid, &status, 0);
+    int status;
+    int ret = EXIT_FAILURE;
+    waitpid(pid, &status, 0);
 
-  if (WIFEXITED(status)) {
-    ret = WEXITSTATUS(status);
-  }
+    if (WIFEXITED(status)) {
+        ret = WEXITSTATUS(status);
+    }
 
-  mem_safe_free(argv);
-  return ret;
+    mem_safe_free(argv);
+    return ret;
 }

--- a/src/os-common/posix/fs.c
+++ b/src/os-common/posix/fs.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -36,8 +36,8 @@
 #include "tm-mem.h"
 
 typedef struct {
-  char  *buf;
-  size_t len;
+    char  *buf;
+    size_t len;
 } tmstr_t;
 
 static tmstr_t Home       = {0};
@@ -49,489 +49,492 @@ static tmstr_t PluginConf = {0};
 static tmstr_t Path       = {0};
 
 static const char *get_home_directory(void) {
-  struct passwd *pw = getpwuid(getuid());
-  return pw->pw_dir;
+    struct passwd *pw = getpwuid(getuid());
+    return pw->pw_dir;
 }
 
 static fs_dirop_status_t simplify(fs_dirop_status_t s) {
-  if (TM_FS_DIROP_STATUS_EXIST == s) {
-    return TM_FS_DIROP_STATUS_OK;
-  }
+    if (TM_FS_DIROP_STATUS_EXIST == s) {
+        return TM_FS_DIROP_STATUS_OK;
+    }
 
-  return s;
+    return s;
 }
 
 static fs_dirop_status_t translate_direrr(void) {
-  switch (errno) {
-  case EACCES:
-    return TM_FS_DIROP_STATUS_PERM;
+    switch (errno) {
+    case EACCES:
+        return TM_FS_DIROP_STATUS_PERM;
 
-  case ENOENT:
-  case ENOTDIR:
-    return TM_FS_DIROP_STATUS_NOEXIST;
+    case ENOENT:
+    case ENOTDIR:
+        return TM_FS_DIROP_STATUS_NOEXIST;
 
-  case EEXIST:
-    return TM_FS_DIROP_STATUS_EXIST;
+    case EEXIST:
+        return TM_FS_DIROP_STATUS_EXIST;
 
-  default:
-    return TM_FS_DIROP_STATUS_ERR;
-  }
+    default:
+        return TM_FS_DIROP_STATUS_ERR;
+    }
 }
 
 static fs_fileop_status_t translate_fileerr(void) {
-  switch (errno) {
-  case EACCES:
-    return TM_FS_FILEOP_STATUS_PERM;
+    switch (errno) {
+    case EACCES:
+        return TM_FS_FILEOP_STATUS_PERM;
 
-  case ENOENT:
-    return TM_FS_FILEOP_STATUS_NOEXIST;
+    case ENOENT:
+        return TM_FS_FILEOP_STATUS_NOEXIST;
 
-  default:
-    return TM_FS_FILEOP_STATUS_ERR;
-  }
+    default:
+        return TM_FS_FILEOP_STATUS_ERR;
+    }
 }
 
 fs_dirop_status_t posix_fs_mkdir(const char *path) {
-  struct stat st = {0};
+    struct stat st = {0};
 
-  if (-1 != stat(path, &st)) {
-    return TM_FS_DIROP_STATUS_EXIST;
-  }
+    if (-1 != stat(path, &st)) {
+        return TM_FS_DIROP_STATUS_EXIST;
+    }
 
-  if (0 == mkdir(path, 0700)) {
-    return TM_FS_DIROP_STATUS_OK;
-  }
+    if (0 == mkdir(path, 0700)) {
+        return TM_FS_DIROP_STATUS_OK;
+    }
 
-  return translate_direrr();
+    return translate_direrr();
 }
 
 fs_dirop_status_t posix_fs_dir_rm(const char *path) {
-  os_fs_dirstream_t dir;
-  fs_dirop_status_t status = os_fs_dir_open(&dir, path);
+    os_fs_dirstream_t dir;
+    fs_dirop_status_t status = os_fs_dir_open(&dir, path);
 
-  if (TM_FS_DIROP_STATUS_OK != status) {
-    return status;
-  }
-
-  fs_dirop_status_t enum_status;
-  fs_dirent_t       ent;
-  while (TM_FS_DIROP_STATUS_END != (enum_status = os_fs_dir_next(dir, &ent))) {
-    if (TM_FS_DIROP_STATUS_OK != enum_status) {
-      return enum_status;
+    if (TM_FS_DIROP_STATUS_OK != status) {
+        return status;
     }
 
-    char *full_path;
-    os_fs_path_dyconcat(&full_path, 2, path, ent.name);
+    fs_dirop_status_t enum_status;
+    fs_dirent_t       ent;
+    while (TM_FS_DIROP_STATUS_END !=
+           (enum_status = os_fs_dir_next(dir, &ent))) {
+        if (TM_FS_DIROP_STATUS_OK != enum_status) {
+            return enum_status;
+        }
 
-    if (NULL == full_path) {
-      return TM_FS_DIROP_STATUS_ERR;
-    }
+        char *full_path;
+        os_fs_path_dyconcat(&full_path, 2, path, ent.name);
 
-    switch (ent.file_type) {
-    case TM_FS_FILETYPE_DIR: {
-      fs_dirop_status_t s = os_fs_dir_rm(full_path);
-      if (TM_FS_DIROP_STATUS_OK != s) {
+        if (NULL == full_path) {
+            return TM_FS_DIROP_STATUS_ERR;
+        }
+
+        switch (ent.file_type) {
+        case TM_FS_FILETYPE_DIR: {
+            fs_dirop_status_t s = os_fs_dir_rm(full_path);
+            if (TM_FS_DIROP_STATUS_OK != s) {
+                mem_safe_free(full_path);
+                return s;
+            }
+            break;
+        }
+
+        case TM_FS_FILETYPE_REGULAR:
+        case TM_FS_FILETYPE_EXEC:
+        case TM_FS_FILETYPE_UNKNOWN:
+            if (0 != unlink(full_path)) {
+                mem_safe_free(full_path);
+                return TM_FS_DIROP_STATUS_ERR;
+            }
+            break;
+        }
+
         mem_safe_free(full_path);
-        return s;
-      }
-      break;
     }
 
-    case TM_FS_FILETYPE_REGULAR:
-    case TM_FS_FILETYPE_EXEC:
-    case TM_FS_FILETYPE_UNKNOWN:
-      if (0 != unlink(full_path)) {
-        mem_safe_free(full_path);
+    status = os_fs_dir_close(dir);
+    if (TM_FS_DIROP_STATUS_OK != status) {
+        return status;
+    }
+
+    if (0 != rmdir(path)) {
         return TM_FS_DIROP_STATUS_ERR;
-      }
-      break;
     }
 
-    mem_safe_free(full_path);
-  }
-
-  status = os_fs_dir_close(dir);
-  if (TM_FS_DIROP_STATUS_OK != status) {
-    return status;
-  }
-
-  if (0 != rmdir(path)) {
-    return TM_FS_DIROP_STATUS_ERR;
-  }
-
-  return TM_FS_DIROP_STATUS_OK;
+    return TM_FS_DIROP_STATUS_OK;
 }
 
 fs_dirop_status_t posix_fs_dir_count(size_t *count, const char *path) {
-  size_t m_count = 0;
+    size_t m_count = 0;
 
-  os_fs_dirstream_t dir;
-  fs_dirop_status_t status = os_fs_dir_open(&dir, path);
+    os_fs_dirstream_t dir;
+    fs_dirop_status_t status = os_fs_dir_open(&dir, path);
 
-  if (TM_FS_DIROP_STATUS_OK != status) {
-    return status;
-  }
-
-  fs_dirop_status_t enum_status;
-  fs_dirent_t       ent;
-  for (; TM_FS_DIROP_STATUS_END != (enum_status = os_fs_dir_next(dir, &ent));
-       m_count++) {
-    if (TM_FS_DIROP_STATUS_OK != enum_status) {
-      return enum_status;
+    if (TM_FS_DIROP_STATUS_OK != status) {
+        return status;
     }
-  }
 
-  *count = m_count;
-  return TM_FS_DIROP_STATUS_OK;
+    fs_dirop_status_t enum_status;
+    fs_dirent_t       ent;
+    for (; TM_FS_DIROP_STATUS_END != (enum_status = os_fs_dir_next(dir, &ent));
+         m_count++) {
+        if (TM_FS_DIROP_STATUS_OK != enum_status) {
+            return enum_status;
+        }
+    }
+
+    *count = m_count;
+    return TM_FS_DIROP_STATUS_OK;
 }
 
 fs_dirop_status_t posix_fs_dir_open(os_fs_dirstream_t *stream,
                                     const char        *path) {
-  DIR *dir = opendir(path);
+    DIR *dir = opendir(path);
 
-  if (NULL == dir) {
-    *stream = NULL;
-    return translate_direrr();
-  }
+    if (NULL == dir) {
+        *stream = NULL;
+        return translate_direrr();
+    }
 
-  *stream = dir;
-  return TM_FS_DIROP_STATUS_OK;
+    *stream = dir;
+    return TM_FS_DIROP_STATUS_OK;
 }
 
 fs_dirop_status_t posix_fs_dir_close(os_fs_dirstream_t stream) {
-  DIR *dir = (DIR *)stream;
+    DIR *dir = (DIR *)stream;
 
-  if (0 == closedir(dir)) {
-    return TM_FS_DIROP_STATUS_OK;
-  }
+    if (0 == closedir(dir)) {
+        return TM_FS_DIROP_STATUS_OK;
+    }
 
-  return TM_FS_DIROP_STATUS_ERR;
+    return TM_FS_DIROP_STATUS_ERR;
 }
 
 fs_dirop_status_t posix_fs_dir_next(os_fs_dirstream_t stream,
                                     fs_dirent_t      *ent) {
-  DIR           *dir  = (DIR *)stream;
-  struct dirent *next = readdir(dir);
+    DIR           *dir  = (DIR *)stream;
+    struct dirent *next = readdir(dir);
 
-  while (NULL != next &&
-         (0 == strcmp(next->d_name, ".") || 0 == strcmp(next->d_name, ".."))) {
-    next = readdir(dir);
-  }
-
-  if (NULL == next) {
-    return TM_FS_DIROP_STATUS_END;
-  }
-
-  int         dird      = dirfd(dir);
-  struct stat st        = {0};
-  bool        stat_done = false;
-
-  if (DT_UNKNOWN == next->d_type) {
-    if (0 > fstatat(dird, next->d_name, &st, 0)) {
-      return TM_FS_DIROP_STATUS_ERR;
+    while (NULL != next && (0 == strcmp(next->d_name, ".") ||
+                            0 == strcmp(next->d_name, ".."))) {
+        next = readdir(dir);
     }
 
-    stat_done = true;
-
-    if (S_ISREG(st.st_mode)) {
-      next->d_type = DT_REG;
-    } else if (S_ISDIR(st.st_mode)) {
-      next->d_type = DT_DIR;
+    if (NULL == next) {
+        return TM_FS_DIROP_STATUS_END;
     }
-  }
 
-  fs_dirent_t m_ent = (fs_dirent_t){.name = next->d_name};
+    int         dird      = dirfd(dir);
+    struct stat st        = {0};
+    bool        stat_done = false;
 
-  switch (next->d_type) {
-  case DT_REG:
-    if (!stat_done && 0 > fstatat(dird, next->d_name, &st, 0)) {
-      return TM_FS_DIROP_STATUS_ERR;
+    if (DT_UNKNOWN == next->d_type) {
+        if (0 > fstatat(dird, next->d_name, &st, 0)) {
+            return TM_FS_DIROP_STATUS_ERR;
+        }
+
+        stat_done = true;
+
+        if (S_ISREG(st.st_mode)) {
+            next->d_type = DT_REG;
+        } else if (S_ISDIR(st.st_mode)) {
+            next->d_type = DT_DIR;
+        }
     }
-    if (S_IXUSR & st.st_mode) {
-      m_ent.file_type = TM_FS_FILETYPE_EXEC;
-    } else {
-      m_ent.file_type = TM_FS_FILETYPE_REGULAR;
+
+    fs_dirent_t m_ent = (fs_dirent_t){.name = next->d_name};
+
+    switch (next->d_type) {
+    case DT_REG:
+        if (!stat_done && 0 > fstatat(dird, next->d_name, &st, 0)) {
+            return TM_FS_DIROP_STATUS_ERR;
+        }
+        if (S_IXUSR & st.st_mode) {
+            m_ent.file_type = TM_FS_FILETYPE_EXEC;
+        } else {
+            m_ent.file_type = TM_FS_FILETYPE_REGULAR;
+        }
+        break;
+
+    case DT_DIR:
+        m_ent.file_type = TM_FS_FILETYPE_DIR;
+        break;
+
+    default:
+        m_ent.file_type = TM_FS_FILETYPE_UNKNOWN;
+        break;
     }
-    break;
 
-  case DT_DIR:
-    m_ent.file_type = TM_FS_FILETYPE_DIR;
-    break;
-
-  default:
-    m_ent.file_type = TM_FS_FILETYPE_UNKNOWN;
-    break;
-  }
-
-  *ent = m_ent;
-  return TM_FS_DIROP_STATUS_OK;
+    *ent = m_ent;
+    return TM_FS_DIROP_STATUS_OK;
 }
 
 fs_fileop_status_t posix_fs_file_rm(const char *path) {
-  if (0 == unlink(path)) {
-    return TM_FS_FILEOP_STATUS_OK;
-  }
+    if (0 == unlink(path)) {
+        return TM_FS_FILEOP_STATUS_OK;
+    }
 
-  return translate_fileerr();
+    return translate_fileerr();
 }
 
 fs_fileop_status_t posix_fs_file_gettype(fs_filetype_t *dst, const char *path) {
-  struct stat st;
+    struct stat st;
 
-  if (0 > stat(path, &st)) {
+    if (0 > stat(path, &st)) {
+        return TM_FS_FILEOP_STATUS_ERR;
+    }
+
+    if (S_ISREG(st.st_mode) && S_IXUSR & st.st_mode) {
+        *dst = TM_FS_FILETYPE_EXEC;
+        return TM_FS_FILEOP_STATUS_OK;
+    }
+
+    if (S_ISREG(st.st_mode)) {
+        *dst = TM_FS_FILETYPE_DIR;
+        return TM_FS_FILEOP_STATUS_OK;
+    }
+
+    if (S_ISDIR(st.st_mode)) {
+        *dst = TM_FS_FILETYPE_DIR;
+        return TM_FS_FILEOP_STATUS_OK;
+    }
+
     return TM_FS_FILEOP_STATUS_ERR;
-  }
-
-  if (S_ISREG(st.st_mode) && S_IXUSR & st.st_mode) {
-    *dst = TM_FS_FILETYPE_EXEC;
-    return TM_FS_FILEOP_STATUS_OK;
-  }
-
-  if (S_ISREG(st.st_mode)) {
-    *dst = TM_FS_FILETYPE_DIR;
-    return TM_FS_FILEOP_STATUS_OK;
-  }
-
-  if (S_ISDIR(st.st_mode)) {
-    *dst = TM_FS_FILETYPE_DIR;
-    return TM_FS_FILEOP_STATUS_OK;
-  }
-
-  return TM_FS_FILEOP_STATUS_ERR;
 }
 
 size_t posix_fs_path_vlen(size_t num_args, va_list args) {
-  size_t len = 0;
+    size_t len = 0;
 
-  for (size_t i = 0; i < num_args; i++) {
-    const char *path = va_arg(args, char *);
-    size_t      plen = strlen(path);
-    len += plen;
-    if ('/' != path[plen - 1]) {
-      len++; // Count the / separator
+    for (size_t i = 0; i < num_args; i++) {
+        const char *path = va_arg(args, char *);
+        size_t      plen = strlen(path);
+        len += plen;
+        if ('/' != path[plen - 1]) {
+            len++; // Count the / separator
+        }
     }
-  }
 
-  return len - 1; // Remove last / separator
+    return len - 1; // Remove last / separator
 }
 
 size_t posix_fs_path_vconcat(char *dst, size_t num_args, va_list args) {
-  size_t j = 0; // Index into dst
+    size_t j = 0; // Index into dst
 
-  for (size_t i = 0; i < num_args; i++) {
-    const char *path = va_arg(args, char *);
-    // Copy path to dst
-    for (; *path; path++, j++) {
-      dst[j] = *path;
+    for (size_t i = 0; i < num_args; i++) {
+        const char *path = va_arg(args, char *);
+        // Copy path to dst
+        for (; *path; path++, j++) {
+            dst[j] = *path;
+        }
+        if ('/' != *(path - 1)) {
+            dst[j] = '/'; // Add separator
+        }
+        j++;
     }
-    if ('/' != *(path - 1)) {
-      dst[j] = '/'; // Add separator
-    }
-    j++;
-  }
 
-  dst[--j] = 0; // Add string terminator
-  return j;
+    dst[--j] = 0; // Add string terminator
+    return j;
 }
 
 size_t posix_fs_path_dyparent(char **dst, const char *path) {
-  size_t last_sep_idx = 0;
+    size_t last_sep_idx = 0;
 
-  for (size_t i = 0; path[i]; i++) {
-    if ('/' == path[i]) {
-      last_sep_idx = i;
+    for (size_t i = 0; path[i]; i++) {
+        if ('/' == path[i]) {
+            last_sep_idx = i;
+        }
     }
-  }
 
-  // If the last separator is also the last char
-  if (!path[last_sep_idx + 1]) {
-    // Avoid situations like: path/to/something//
-    //                                          ^
+    // If the last separator is also the last char
+    if (!path[last_sep_idx + 1]) {
+        // Avoid situations like: path/to/something//
+        //                                          ^
+        for (size_t back = last_sep_idx - 1; back > 0 && '/' == path[back];
+             back--) {
+            last_sep_idx = back;
+        }
+
+        // Move back to previous /
+        for (size_t back = last_sep_idx - 1; back > 0 && '/' != path[back];
+             back--) {
+            last_sep_idx = back;
+        }
+
+        // Point to last / instead of char
+        last_sep_idx--;
+    }
+
+    // Avoid issues like path//to//////something/////////
     for (size_t back = last_sep_idx - 1; back > 0 && '/' == path[back];
          back--) {
-      last_sep_idx = back;
+        last_sep_idx = back;
     }
 
-    // Move back to previous /
-    for (size_t back = last_sep_idx - 1; back > 0 && '/' != path[back];
-         back--) {
-      last_sep_idx = back;
+    const char *target_path = path;
+
+    if (0 == last_sep_idx) {
+        last_sep_idx++;
+        target_path = ".";
     }
 
-    // Point to last / instead of char
-    last_sep_idx--;
-  }
+    size_t buf_len = last_sep_idx + 1;
+    char  *buf     = (char *)malloc(buf_len * sizeof(char));
 
-  // Avoid issues like path//to//////something/////////
-  for (size_t back = last_sep_idx - 1; back > 0 && '/' == path[back]; back--) {
-    last_sep_idx = back;
-  }
+    mem_chkoom(buf);
+    // if (NULL == buf) {
+    //   *dst = NULL;
+    //   return 0;
+    // }
 
-  const char *target_path = path;
+    strncpy(buf, target_path, last_sep_idx);
+    buf[last_sep_idx] = 0; // Add string terminator
 
-  if (0 == last_sep_idx) {
-    last_sep_idx++;
-    target_path = ".";
-  }
-
-  size_t buf_len = last_sep_idx + 1;
-  char  *buf     = (char *)malloc(buf_len * sizeof(char));
-
-  mem_chkoom(buf);
-  // if (NULL == buf) {
-  //   *dst = NULL;
-  //   return 0;
-  // }
-
-  strncpy(buf, target_path, last_sep_idx);
-  buf[last_sep_idx] = 0; // Add string terminator
-
-  *dst = buf;
-  return buf_len;
+    *dst = buf;
+    return buf_len;
 }
 
 size_t posix_fs_tm_dyhome(char **dst) {
-  char *tm_home = (char *)malloc((Home.len + 1) * sizeof(char));
-  mem_chkoom(tm_home);
-  strcpy(tm_home, Home.buf);
-  *dst = tm_home;
-  return Home.len;
+    char *tm_home = (char *)malloc((Home.len + 1) * sizeof(char));
+    mem_chkoom(tm_home);
+    strcpy(tm_home, Home.buf);
+    *dst = tm_home;
+    return Home.len;
 }
 
 size_t posix_fs_tm_dyrepos(char **dst) {
-  char *tm_repos = (char *)malloc((Repos.len + 1) * sizeof(char));
-  mem_chkoom(tm_repos);
-  strcpy(tm_repos, Repos.buf);
-  *dst = tm_repos;
-  return Repos.len;
+    char *tm_repos = (char *)malloc((Repos.len + 1) * sizeof(char));
+    mem_chkoom(tm_repos);
+    strcpy(tm_repos, Repos.buf);
+    *dst = tm_repos;
+    return Repos.len;
 }
 
 size_t posix_fs_tm_dypkgs(char **dst) {
-  char *tm_pkgs = (char *)malloc((Pkgs.len + 1) * sizeof(char));
-  mem_chkoom(tm_pkgs);
-  strcpy(tm_pkgs, Pkgs.buf);
-  *dst = tm_pkgs;
-  return Pkgs.len;
+    char *tm_pkgs = (char *)malloc((Pkgs.len + 1) * sizeof(char));
+    mem_chkoom(tm_pkgs);
+    strcpy(tm_pkgs, Pkgs.buf);
+    *dst = tm_pkgs;
+    return Pkgs.len;
 }
 
 size_t posix_fs_tm_dyextract(char **dst) {
-  char *tm_extract = (char *)malloc((Extract.len + 1) * sizeof(char));
-  mem_chkoom(tm_extract);
-  strcpy(tm_extract, Extract.buf);
-  *dst = tm_extract;
-  return Extract.len;
+    char *tm_extract = (char *)malloc((Extract.len + 1) * sizeof(char));
+    mem_chkoom(tm_extract);
+    strcpy(tm_extract, Extract.buf);
+    *dst = tm_extract;
+    return Extract.len;
 }
 
 size_t posix_fs_tm_dyrepo(char **dst, const char *repo_name) {
-  char  *tm_repo;
-  size_t ret = os_fs_path_dyconcat(&tm_repo, 2, Repos.buf, repo_name);
-  mem_chkoom(tm_repo);
-  *dst = tm_repo;
-  return ret;
+    char  *tm_repo;
+    size_t ret = os_fs_path_dyconcat(&tm_repo, 2, Repos.buf, repo_name);
+    mem_chkoom(tm_repo);
+    *dst = tm_repo;
+    return ret;
 }
 
 size_t posix_fs_tm_dypkg(char **dst, const char *pkg_name) {
-  char  *tm_pkg;
-  size_t ret = os_fs_path_dyconcat(&tm_pkg, 2, Pkgs.buf, pkg_name);
-  mem_chkoom(tm_pkg);
-  *dst = tm_pkg;
-  return ret;
+    char  *tm_pkg;
+    size_t ret = os_fs_path_dyconcat(&tm_pkg, 2, Pkgs.buf, pkg_name);
+    mem_chkoom(tm_pkg);
+    *dst = tm_pkg;
+    return ret;
 }
 
 size_t posix_fs_tm_dycached(char **dst, const char *item_name) {
-  char  *tm_cached;
-  size_t ret = os_fs_path_dyconcat(&tm_cached, 2, Extract.buf, item_name);
-  mem_chkoom(tm_cached);
-  *dst = tm_cached;
-  return ret;
+    char  *tm_cached;
+    size_t ret = os_fs_path_dyconcat(&tm_cached, 2, Extract.buf, item_name);
+    mem_chkoom(tm_cached);
+    *dst = tm_cached;
+    return ret;
 }
 
 size_t
 posix_fs_tm_dyrecipe(char **dst, const char *repo_name, const char *pkg_name) {
-  size_t ret = 0;
+    size_t ret = 0;
 
-  char *rec_name =
-      (char *)malloc((strlen(pkg_name) + strlen(".tarman") + 1) * sizeof(char));
-  mem_chkoom(rec_name);
-  sprintf(rec_name, "%s.tarman", pkg_name);
+    char *rec_name = (char *)malloc((strlen(pkg_name) + strlen(".tarman") + 1) *
+                                    sizeof(char));
+    mem_chkoom(rec_name);
+    sprintf(rec_name, "%s.tarman", pkg_name);
 
-  char *tm_recipe;
-  ret = os_fs_path_dyconcat(&tm_recipe, 3, Repos.buf, repo_name, rec_name);
+    char *tm_recipe;
+    ret = os_fs_path_dyconcat(&tm_recipe, 3, Repos.buf, repo_name, rec_name);
 
-  mem_safe_free(rec_name);
-  *dst = tm_recipe;
-  return ret;
+    mem_safe_free(rec_name);
+    *dst = tm_recipe;
+    return ret;
 }
 
 size_t posix_fs_tm_dyplugins(const char **dst) {
-  char *tm_plugins = (char *)malloc((Plugins.len + 1) * sizeof(char));
-  mem_chkoom(tm_plugins);
-  strcpy(tm_plugins, Plugins.buf);
-  *dst = tm_plugins;
-  return Plugins.len;
+    char *tm_plugins = (char *)malloc((Plugins.len + 1) * sizeof(char));
+    mem_chkoom(tm_plugins);
+    strcpy(tm_plugins, Plugins.buf);
+    *dst = tm_plugins;
+    return Plugins.len;
 }
 
 size_t posix_fs_tm_dyplugin(const char **dst, const char *plugin) {
-  char  *tm_plugin;
-  size_t ret = os_fs_path_dyconcat(&tm_plugin, 2, Plugins.buf, plugin);
-  mem_chkoom(tm_plugin);
-  *dst = tm_plugin;
-  return ret;
+    char  *tm_plugin;
+    size_t ret = os_fs_path_dyconcat(&tm_plugin, 2, Plugins.buf, plugin);
+    mem_chkoom(tm_plugin);
+    *dst = tm_plugin;
+    return ret;
 }
 
 size_t posix_fs_tm_dyplugconf(const char **dst, const char *plugin) {
-  size_t ret = 0;
+    size_t ret = 0;
 
-  char *conf_name =
-      (char *)malloc((strlen(plugin) + strlen(".txt") + 1) * sizeof(char));
-  mem_chkoom(conf_name);
-  sprintf(conf_name, "%s.txt", plugin);
+    char *conf_name =
+        (char *)malloc((strlen(plugin) + strlen(".txt") + 1) * sizeof(char));
+    mem_chkoom(conf_name);
+    sprintf(conf_name, "%s.txt", plugin);
 
-  char *tm_plugconf;
-  ret = os_fs_path_dyconcat(&tm_plugconf, 2, PluginConf.buf, conf_name);
+    char *tm_plugconf;
+    ret = os_fs_path_dyconcat(&tm_plugconf, 2, PluginConf.buf, conf_name);
 
-  mem_safe_free(conf_name);
-  *dst = tm_plugconf;
-  return ret;
+    mem_safe_free(conf_name);
+    *dst = tm_plugconf;
+    return ret;
 }
 
 size_t posix_fs_tm_dyexecpath(const char **dst, const char *exec) {
-  char  *tm_pathexec;
-  size_t ret = os_fs_path_dyconcat(&tm_pathexec, 2, Path.buf, exec);
-  mem_chkoom(tm_pathexec);
-  *dst = tm_pathexec;
-  return ret;
+    char  *tm_pathexec;
+    size_t ret = os_fs_path_dyconcat(&tm_pathexec, 2, Path.buf, exec);
+    mem_chkoom(tm_pathexec);
+    *dst = tm_pathexec;
+    return ret;
 }
 
 bool posix_fs_tm_init(void) {
-  const char *usr_home = get_home_directory();
+    const char *usr_home = get_home_directory();
 
-  Home.len  = os_fs_path_dyconcat(&Home.buf, 2, usr_home, ".tarman");
-  Repos.len = os_fs_path_dyconcat(&Repos.buf, 3, usr_home, ".tarman", "repos");
-  Pkgs.len  = os_fs_path_dyconcat(&Pkgs.buf, 3, usr_home, ".tarman", "pkgs");
-  Extract.len =
-      os_fs_path_dyconcat(&Extract.buf, 3, usr_home, ".tarman", "tmp");
-  Plugins.len =
-      os_fs_path_dyconcat(&Plugins.buf, 3, usr_home, ".tarman", "plugins");
-  PluginConf.len =
-      os_fs_path_dyconcat(&PluginConf.buf, 3, usr_home, ".tarman", "conf");
-  Path.len = os_fs_path_dyconcat(&Path.buf, 3, usr_home, ".tarman", "path");
+    Home.len = os_fs_path_dyconcat(&Home.buf, 2, usr_home, ".tarman");
+    Repos.len =
+        os_fs_path_dyconcat(&Repos.buf, 3, usr_home, ".tarman", "repos");
+    Pkgs.len = os_fs_path_dyconcat(&Pkgs.buf, 3, usr_home, ".tarman", "pkgs");
+    Extract.len =
+        os_fs_path_dyconcat(&Extract.buf, 3, usr_home, ".tarman", "tmp");
+    Plugins.len =
+        os_fs_path_dyconcat(&Plugins.buf, 3, usr_home, ".tarman", "plugins");
+    PluginConf.len =
+        os_fs_path_dyconcat(&PluginConf.buf, 3, usr_home, ".tarman", "conf");
+    Path.len = os_fs_path_dyconcat(&Path.buf, 3, usr_home, ".tarman", "path");
 
-  if (NULL == Home.buf || NULL == Repos.buf || NULL == Pkgs.buf ||
-      NULL == Extract.buf || NULL == Plugins.buf || NULL == PluginConf.buf ||
-      NULL == Path.buf) {
-    return false;
-  }
+    if (NULL == Home.buf || NULL == Repos.buf || NULL == Pkgs.buf ||
+        NULL == Extract.buf || NULL == Plugins.buf || NULL == PluginConf.buf ||
+        NULL == Path.buf) {
+        return false;
+    }
 
-  if (TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(Home.buf)) ||
-      TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(Repos.buf)) ||
-      TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(Pkgs.buf)) ||
-      TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(Extract.buf)) ||
-      TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(Plugins.buf)) ||
-      TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(PluginConf.buf)) ||
-      TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(Path.buf))) {
-    return false;
-  }
+    if (TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(Home.buf)) ||
+        TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(Repos.buf)) ||
+        TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(Pkgs.buf)) ||
+        TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(Extract.buf)) ||
+        TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(Plugins.buf)) ||
+        TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(PluginConf.buf)) ||
+        TM_FS_DIROP_STATUS_OK != simplify(os_fs_mkdir(Path.buf))) {
+        return false;
+    }
 
-  return true;
+    return true;
 }

--- a/src/os-specific/darwin/Makefile
+++ b/src/os-specific/darwin/Makefile
@@ -1,5 +1,5 @@
 # tarman
-# Copyright (C) 2024 Alessandro Salerno
+# Copyright (C) 2024 - 2025 Alessandro Salerno
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/os-specific/darwin/console.c
+++ b/src/os-specific/darwin/console.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -21,9 +21,9 @@
 #include "os/console.h"
 
 csz_t os_console_get_sz(void) {
-  return posix_console_get_sz();
+    return posix_console_get_sz();
 }
 
 void os_console_set_color(color_t color, bool bold) {
-  posix_console_set_color(color, bold);
+    posix_console_set_color(color, bold);
 }

--- a/src/os-specific/darwin/env.c
+++ b/src/os-specific/darwin/env.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -23,27 +23,27 @@
 #include "os/posix/env.h"
 
 bool os_env_path_add(const char *executable) {
-  return posix_env_path_add(executable);
+    return posix_env_path_add(executable);
 }
 
 bool os_env_path_rm(const char *executable) {
-  return posix_env_path_rm(executable);
+    return posix_env_path_rm(executable);
 }
 
 bool os_env_desktop_add(const char *app_name,
                         const char *executable_path,
                         const char *icon_path,
                         const char *wrk_dir) {
-  // Not implemented
-  (void)app_name;
-  (void)executable_path;
-  (void)icon_path;
-  (void)wrk_dir;
-  return false;
+    // Not implemented
+    (void)app_name;
+    (void)executable_path;
+    (void)icon_path;
+    (void)wrk_dir;
+    return false;
 }
 
 bool os_env_desktop_rm(const char *app_name) {
-  // Not implemented
-  (void)app_name;
-  return false;
+    // Not implemented
+    (void)app_name;
+    return false;
 }

--- a/src/os-specific/darwin/exec.c
+++ b/src/os-specific/darwin/exec.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -22,13 +22,13 @@
 #include "os/posix/exec.h"
 
 int os_vexec(const char *executable, va_list args) {
-  return posix_vexec(executable, args);
+    return posix_vexec(executable, args);
 }
 
 int os_exec(const char *executable, ...) {
-  va_list args;
-  va_start(args, executable);
-  int ret = os_vexec(executable, args);
-  va_end(args);
-  return ret;
+    va_list args;
+    va_start(args, executable);
+    int ret = os_vexec(executable, args);
+    va_end(args);
+    return ret;
 }

--- a/src/os-specific/darwin/fs.c
+++ b/src/os-specific/darwin/fs.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -21,132 +21,132 @@
 #include "os/posix/fs.h"
 
 fs_dirop_status_t os_fs_mkdir(const char *path) {
-  return posix_fs_mkdir(path);
+    return posix_fs_mkdir(path);
 }
 
 fs_dirop_status_t os_fs_dir_rm(const char *path) {
-  return posix_fs_dir_rm(path);
+    return posix_fs_dir_rm(path);
 }
 
 fs_dirop_status_t os_fs_dir_count(size_t *count, const char *path) {
-  return posix_fs_dir_count(count, path);
+    return posix_fs_dir_count(count, path);
 }
 
 fs_dirop_status_t os_fs_dir_open(os_fs_dirstream_t *stream, const char *path) {
-  return posix_fs_dir_open(stream, path);
+    return posix_fs_dir_open(stream, path);
 }
 
 fs_dirop_status_t os_fs_dir_close(os_fs_dirstream_t stream) {
-  return posix_fs_dir_close(stream);
+    return posix_fs_dir_close(stream);
 }
 
 fs_dirop_status_t os_fs_dir_next(os_fs_dirstream_t stream, fs_dirent_t *ent) {
-  return posix_fs_dir_next(stream, ent);
+    return posix_fs_dir_next(stream, ent);
 }
 
 fs_fileop_status_t os_fs_file_rm(const char *path) {
-  return posix_fs_file_rm(path);
+    return posix_fs_file_rm(path);
 }
 
 fs_fileop_status_t os_fs_file_gettype(fs_filetype_t *dst, const char *path) {
-  return posix_fs_file_gettype(dst, path);
+    return posix_fs_file_gettype(dst, path);
 }
 
 size_t os_fs_path_vlen(size_t num_args, va_list args) {
-  return posix_fs_path_vlen(num_args, args);
+    return posix_fs_path_vlen(num_args, args);
 }
 
 size_t os_fs_path_len(size_t num_args, ...) {
-  va_list args;
-  va_start(args, num_args);
-  size_t ret = os_fs_path_vlen(num_args, args);
-  va_end(args);
-  return ret;
+    va_list args;
+    va_start(args, num_args);
+    size_t ret = os_fs_path_vlen(num_args, args);
+    va_end(args);
+    return ret;
 }
 
 size_t os_fs_path_vconcat(char *dst, size_t num_args, va_list args) {
-  return posix_fs_path_vconcat(dst, num_args, args);
+    return posix_fs_path_vconcat(dst, num_args, args);
 }
 
 size_t os_fs_path_concat(char *dst, size_t num_args, ...) {
-  va_list args;
-  va_start(args, num_args);
-  size_t ret = os_fs_path_vconcat(dst, num_args, args);
-  va_end(args);
-  return ret;
+    va_list args;
+    va_start(args, num_args);
+    size_t ret = os_fs_path_vconcat(dst, num_args, args);
+    va_end(args);
+    return ret;
 }
 
 size_t os_fs_path_dyconcat(char **dst, size_t num_args, ...) {
-  va_list args;
-  va_start(args, num_args);
-  size_t len = os_fs_path_vlen(num_args, args);
-  va_end(args);
+    va_list args;
+    va_start(args, num_args);
+    size_t len = os_fs_path_vlen(num_args, args);
+    va_end(args);
 
-  size_t buf_sz = len + 1;
-  char  *buf    = (char *)malloc(buf_sz * sizeof(char));
+    size_t buf_sz = len + 1;
+    char  *buf    = (char *)malloc(buf_sz * sizeof(char));
 
-  if (NULL == buf) {
-    *dst = NULL;
-    return 0;
-  }
+    if (NULL == buf) {
+        *dst = NULL;
+        return 0;
+    }
 
-  va_start(args, num_args);
-  os_fs_path_vconcat(buf, num_args, args);
-  va_end(args);
+    va_start(args, num_args);
+    os_fs_path_vconcat(buf, num_args, args);
+    va_end(args);
 
-  *dst = buf;
-  return len;
+    *dst = buf;
+    return len;
 }
 
 size_t os_fs_path_dyparent(char **dst, const char *path) {
-  return posix_fs_path_dyparent(dst, path);
+    return posix_fs_path_dyparent(dst, path);
 }
 
 size_t os_fs_tm_dyhome(char **dst) {
-  return posix_fs_tm_dyhome(dst);
+    return posix_fs_tm_dyhome(dst);
 }
 
 size_t os_fs_tm_dyrepos(char **dst) {
-  return posix_fs_tm_dyrepos(dst);
+    return posix_fs_tm_dyrepos(dst);
 }
 
 size_t os_fs_tm_dypkgs(char **dst) {
-  return posix_fs_tm_dypkgs(dst);
+    return posix_fs_tm_dypkgs(dst);
 }
 
 size_t os_fs_tm_dyextract(char **dst) {
-  return posix_fs_tm_dyextract(dst);
+    return posix_fs_tm_dyextract(dst);
 }
 
 size_t os_fs_tm_dyrepo(char **dst, const char *repo_name) {
-  return posix_fs_tm_dyrepo(dst, repo_name);
+    return posix_fs_tm_dyrepo(dst, repo_name);
 }
 
 size_t os_fs_tm_dypkg(char **dst, const char *pkg_name) {
-  return posix_fs_tm_dypkg(dst, pkg_name);
+    return posix_fs_tm_dypkg(dst, pkg_name);
 }
 
 size_t os_fs_tm_dycached(char **dst, const char *item_name) {
-  return posix_fs_tm_dycached(dst, item_name);
+    return posix_fs_tm_dycached(dst, item_name);
 }
 
 size_t
 os_fs_tm_dyrecipe(char **dst, const char *repo_name, const char *pkg_name) {
-  return posix_fs_tm_dyrecipe(dst, repo_name, pkg_name);
+    return posix_fs_tm_dyrecipe(dst, repo_name, pkg_name);
 }
 
 size_t os_fs_tm_dyplugins(const char **dst) {
-  return posix_fs_tm_dyplugins(dst);
+    return posix_fs_tm_dyplugins(dst);
 }
 
 size_t os_fs_tm_dyplugin(const char **dst, const char *plugin) {
-  return posix_fs_tm_dyplugin(dst, plugin);
+    return posix_fs_tm_dyplugin(dst, plugin);
 }
 
 size_t os_fs_tm_dyplugconf(const char **dst, const char *plugin) {
-  return posix_fs_tm_dyplugconf(dst, plugin);
+    return posix_fs_tm_dyplugconf(dst, plugin);
 }
 
 bool os_fs_tm_init(void) {
-  return posix_fs_tm_init();
+    return posix_fs_tm_init();
 }

--- a/src/os-specific/linux/Makefile
+++ b/src/os-specific/linux/Makefile
@@ -1,5 +1,5 @@
 # tarman
-# Copyright (C) 2024 Alessandro Salerno
+# Copyright (C) 2024 - 2025 Alessandro Salerno
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/os-specific/linux/console.c
+++ b/src/os-specific/linux/console.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -21,9 +21,9 @@
 #include "os/console.h"
 
 csz_t os_console_get_sz(void) {
-  return posix_console_get_sz();
+    return posix_console_get_sz();
 }
 
 void os_console_set_color(color_t color, bool bold) {
-  posix_console_set_color(color, bold);
+    posix_console_set_color(color, bold);
 }

--- a/src/os-specific/linux/env.c
+++ b/src/os-specific/linux/env.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -27,107 +27,107 @@
 #include "tm-mem.h"
 
 static const char *get_home_directory(void) {
-  struct passwd *pw = getpwuid(getuid());
-  return pw->pw_dir;
+    struct passwd *pw = getpwuid(getuid());
+    return pw->pw_dir;
 }
 
 bool os_env_path_add(const char *executable) {
-  return posix_env_path_add(executable);
+    return posix_env_path_add(executable);
 }
 
 bool os_env_path_rm(const char *executable) {
-  return posix_env_path_rm(executable);
+    return posix_env_path_rm(executable);
 }
 
 bool os_env_desktop_add(const char *app_name,
                         const char *executable_path,
                         const char *icon_path,
                         const char *wrk_dir) {
-  if (NULL == app_name) {
-    return false;
-  }
+    if (NULL == app_name) {
+        return false;
+    }
 
-  const char *usr_home      = get_home_directory();
-  const char *app_file_path = NULL;
+    const char *usr_home      = get_home_directory();
+    const char *app_file_path = NULL;
 
-  size_t app_bufflen   = strlen(app_name) + 1 + strlen("desktop") + 1;
-  char  *app_file_name = (char *)malloc(app_bufflen * sizeof(char));
-  mem_chkoom(app_file_name);
-  snprintf(app_file_name, app_bufflen, "%s.%s", app_name, "desktop");
+    size_t app_bufflen   = strlen(app_name) + 1 + strlen("desktop") + 1;
+    char  *app_file_name = (char *)malloc(app_bufflen * sizeof(char));
+    mem_chkoom(app_file_name);
+    snprintf(app_file_name, app_bufflen, "%s.%s", app_name, "desktop");
 
-  if (0 == os_fs_path_dyconcat((char **)&app_file_path,
-                               5,
-                               usr_home,
-                               ".local",
-                               "share",
-                               "applications",
-                               app_file_name)) {
-    mem_safe_free(app_file_name);
-    return false;
-  }
+    if (0 == os_fs_path_dyconcat((char **)&app_file_path,
+                                 5,
+                                 usr_home,
+                                 ".local",
+                                 "share",
+                                 "applications",
+                                 app_file_name)) {
+        mem_safe_free(app_file_name);
+        return false;
+    }
 
-  bool  ret = false;
-  FILE *fp  = fopen(app_file_path, "w");
+    bool  ret = false;
+    FILE *fp  = fopen(app_file_path, "w");
 
-  if (NULL == fp) {
-    goto cleanup;
-  }
+    if (NULL == fp) {
+        goto cleanup;
+    }
 
-  fprintf(fp, "[Desktop Entry]\n");
-  fprintf(fp, "Comment=Installed with tarman\n");
-  fprintf(fp, "Exec=%s\n", executable_path);
+    fprintf(fp, "[Desktop Entry]\n");
+    fprintf(fp, "Comment=Installed with tarman\n");
+    fprintf(fp, "Exec=%s\n", executable_path);
 
-  if (NULL != icon_path) {
-    fprintf(fp, "Icon=%s\n", icon_path);
-  }
+    if (NULL != icon_path) {
+        fprintf(fp, "Icon=%s\n", icon_path);
+    }
 
-  fprintf(fp, "Name=%s\n", app_name);
-  fprintf(fp, "NoDisplay=false\n");
+    fprintf(fp, "Name=%s\n", app_name);
+    fprintf(fp, "NoDisplay=false\n");
 
-  if (NULL != wrk_dir) {
-    fprintf(fp, "Path=%s\n", wrk_dir);
-  }
+    if (NULL != wrk_dir) {
+        fprintf(fp, "Path=%s\n", wrk_dir);
+    }
 
-  fprintf(fp, "StartupNotify=true\n");
-  fprintf(fp, "Terminal=false\n");
-  fprintf(fp, "TerminalOptions=\n");
-  fprintf(fp, "Type=Application\n");
+    fprintf(fp, "StartupNotify=true\n");
+    fprintf(fp, "Terminal=false\n");
+    fprintf(fp, "TerminalOptions=\n");
+    fprintf(fp, "Type=Application\n");
 
-  fclose(fp);
-  ret = true;
+    fclose(fp);
+    ret = true;
 
 cleanup:
-  mem_safe_free(app_file_name);
-  mem_safe_free(app_file_path);
-  return ret;
+    mem_safe_free(app_file_name);
+    mem_safe_free(app_file_path);
+    return ret;
 }
 
 bool os_env_desktop_rm(const char *app_name) {
-  if (NULL == app_name) {
-    return false;
-  }
+    if (NULL == app_name) {
+        return false;
+    }
 
-  const char *usr_home      = get_home_directory();
-  const char *app_file_path = NULL;
+    const char *usr_home      = get_home_directory();
+    const char *app_file_path = NULL;
 
-  size_t app_bufflen   = strlen(app_name) + 1 + strlen("desktop") + 1;
-  char  *app_file_name = (char *)malloc(app_bufflen * sizeof(char));
-  mem_chkoom(app_file_name);
-  snprintf(app_file_name, app_bufflen, "%s.%s", app_name, "desktop");
+    size_t app_bufflen   = strlen(app_name) + 1 + strlen("desktop") + 1;
+    char  *app_file_name = (char *)malloc(app_bufflen * sizeof(char));
+    mem_chkoom(app_file_name);
+    snprintf(app_file_name, app_bufflen, "%s.%s", app_name, "desktop");
 
-  if (0 == os_fs_path_dyconcat((char **)&app_file_path,
-                               5,
-                               usr_home,
-                               ".local",
-                               "share",
-                               "applications",
-                               app_file_name)) {
+    if (0 == os_fs_path_dyconcat((char **)&app_file_path,
+                                 5,
+                                 usr_home,
+                                 ".local",
+                                 "share",
+                                 "applications",
+                                 app_file_name)) {
+        mem_safe_free(app_file_name);
+        return false;
+    }
+
+    fs_fileop_status_t rm_status = os_fs_file_rm(app_file_path);
     mem_safe_free(app_file_name);
-    return false;
-  }
-
-  fs_fileop_status_t rm_status = os_fs_file_rm(app_file_path);
-  mem_safe_free(app_file_name);
-  mem_safe_free(app_file_path);
-  return TM_FS_FILEOP_STATUS_OK == rm_status;
+    mem_safe_free(app_file_path);
+    return TM_FS_FILEOP_STATUS_OK == rm_status;
 }

--- a/src/os-specific/linux/exec.c
+++ b/src/os-specific/linux/exec.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -22,13 +22,13 @@
 #include "os/posix/exec.h"
 
 int os_vexec(const char *executable, va_list args) {
-  return posix_vexec(executable, args);
+    return posix_vexec(executable, args);
 }
 
 int os_exec(const char *executable, ...) {
-  va_list args;
-  va_start(args, executable);
-  int ret = os_vexec(executable, args);
-  va_end(args);
-  return ret;
+    va_list args;
+    va_start(args, executable);
+    int ret = os_vexec(executable, args);
+    va_end(args);
+    return ret;
 }

--- a/src/os-specific/linux/fs.c
+++ b/src/os-specific/linux/fs.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -21,132 +21,132 @@
 #include "os/fs.h"
 
 fs_dirop_status_t os_fs_mkdir(const char *path) {
-  return posix_fs_mkdir(path);
+    return posix_fs_mkdir(path);
 }
 
 fs_dirop_status_t os_fs_dir_rm(const char *path) {
-  return posix_fs_dir_rm(path);
+    return posix_fs_dir_rm(path);
 }
 
 fs_dirop_status_t os_fs_dir_count(size_t *count, const char *path) {
-  return posix_fs_dir_count(count, path);
+    return posix_fs_dir_count(count, path);
 }
 
 fs_dirop_status_t os_fs_dir_open(os_fs_dirstream_t *stream, const char *path) {
-  return posix_fs_dir_open(stream, path);
+    return posix_fs_dir_open(stream, path);
 }
 
 fs_dirop_status_t os_fs_dir_close(os_fs_dirstream_t stream) {
-  return posix_fs_dir_close(stream);
+    return posix_fs_dir_close(stream);
 }
 
 fs_dirop_status_t os_fs_dir_next(os_fs_dirstream_t stream, fs_dirent_t *ent) {
-  return posix_fs_dir_next(stream, ent);
+    return posix_fs_dir_next(stream, ent);
 }
 
 fs_fileop_status_t os_fs_file_rm(const char *path) {
-  return posix_fs_file_rm(path);
+    return posix_fs_file_rm(path);
 }
 
 fs_fileop_status_t os_fs_file_gettype(fs_filetype_t *dst, const char *path) {
-  return posix_fs_file_gettype(dst, path);
+    return posix_fs_file_gettype(dst, path);
 }
 
 size_t os_fs_path_vlen(size_t num_args, va_list args) {
-  return posix_fs_path_vlen(num_args, args);
+    return posix_fs_path_vlen(num_args, args);
 }
 
 size_t os_fs_path_len(size_t num_args, ...) {
-  va_list args;
-  va_start(args, num_args);
-  size_t ret = os_fs_path_vlen(num_args, args);
-  va_end(args);
-  return ret;
+    va_list args;
+    va_start(args, num_args);
+    size_t ret = os_fs_path_vlen(num_args, args);
+    va_end(args);
+    return ret;
 }
 
 size_t os_fs_path_vconcat(char *dst, size_t num_args, va_list args) {
-  return posix_fs_path_vconcat(dst, num_args, args);
+    return posix_fs_path_vconcat(dst, num_args, args);
 }
 
 size_t os_fs_path_concat(char *dst, size_t num_args, ...) {
-  va_list args;
-  va_start(args, num_args);
-  size_t ret = os_fs_path_vconcat(dst, num_args, args);
-  va_end(args);
-  return ret;
+    va_list args;
+    va_start(args, num_args);
+    size_t ret = os_fs_path_vconcat(dst, num_args, args);
+    va_end(args);
+    return ret;
 }
 
 size_t os_fs_path_dyconcat(char **dst, size_t num_args, ...) {
-  va_list args;
-  va_start(args, num_args);
-  size_t len = os_fs_path_vlen(num_args, args);
-  va_end(args);
+    va_list args;
+    va_start(args, num_args);
+    size_t len = os_fs_path_vlen(num_args, args);
+    va_end(args);
 
-  size_t buf_sz = len + 1;
-  char  *buf    = (char *)malloc(buf_sz * sizeof(char));
+    size_t buf_sz = len + 1;
+    char  *buf    = (char *)malloc(buf_sz * sizeof(char));
 
-  if (NULL == buf) {
-    *dst = NULL;
-    return 0;
-  }
+    if (NULL == buf) {
+        *dst = NULL;
+        return 0;
+    }
 
-  va_start(args, num_args);
-  os_fs_path_vconcat(buf, num_args, args);
-  va_end(args);
+    va_start(args, num_args);
+    os_fs_path_vconcat(buf, num_args, args);
+    va_end(args);
 
-  *dst = buf;
-  return len;
+    *dst = buf;
+    return len;
 }
 
 size_t os_fs_path_dyparent(char **dst, const char *path) {
-  return posix_fs_path_dyparent(dst, path);
+    return posix_fs_path_dyparent(dst, path);
 }
 
 size_t os_fs_tm_dyhome(char **dst) {
-  return posix_fs_tm_dyhome(dst);
+    return posix_fs_tm_dyhome(dst);
 }
 
 size_t os_fs_tm_dyrepos(char **dst) {
-  return posix_fs_tm_dyrepos(dst);
+    return posix_fs_tm_dyrepos(dst);
 }
 
 size_t os_fs_tm_dypkgs(char **dst) {
-  return posix_fs_tm_dypkgs(dst);
+    return posix_fs_tm_dypkgs(dst);
 }
 
 size_t os_fs_tm_dyextract(char **dst) {
-  return posix_fs_tm_dyextract(dst);
+    return posix_fs_tm_dyextract(dst);
 }
 
 size_t os_fs_tm_dyrepo(char **dst, const char *repo_name) {
-  return posix_fs_tm_dyrepo(dst, repo_name);
+    return posix_fs_tm_dyrepo(dst, repo_name);
 }
 
 size_t os_fs_tm_dypkg(char **dst, const char *pkg_name) {
-  return posix_fs_tm_dypkg(dst, pkg_name);
+    return posix_fs_tm_dypkg(dst, pkg_name);
 }
 
 size_t os_fs_tm_dycached(char **dst, const char *item_name) {
-  return posix_fs_tm_dycached(dst, item_name);
+    return posix_fs_tm_dycached(dst, item_name);
 }
 
 size_t
 os_fs_tm_dyrecipe(char **dst, const char *repo_name, const char *pkg_name) {
-  return posix_fs_tm_dyrecipe(dst, repo_name, pkg_name);
+    return posix_fs_tm_dyrecipe(dst, repo_name, pkg_name);
 }
 
 size_t os_fs_tm_dyplugins(const char **dst) {
-  return posix_fs_tm_dyplugins(dst);
+    return posix_fs_tm_dyplugins(dst);
 }
 
 size_t os_fs_tm_dyplugin(const char **dst, const char *plugin) {
-  return posix_fs_tm_dyplugin(dst, plugin);
+    return posix_fs_tm_dyplugin(dst, plugin);
 }
 
 size_t os_fs_tm_dyplugconf(const char **dst, const char *plugin) {
-  return posix_fs_tm_dyplugconf(dst, plugin);
+    return posix_fs_tm_dyplugconf(dst, plugin);
 }
 
 bool os_fs_tm_init(void) {
-  return posix_fs_tm_init();
+    return posix_fs_tm_init();
 }

--- a/src/plugin-sdk/loader.c
+++ b/src/plugin-sdk/loader.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -23,10 +23,10 @@
 #include "plugin/sdk.h"
 
 int main(int argc, char *argv[]) {
-  if (4 != argc) {
-    return EXIT_FAILURE;
-  }
+    if (4 != argc) {
+        return EXIT_FAILURE;
+    }
 
-  sdk_handover_t handover = {.src = argv[1], .dst = argv[2], .cfg = argv[3]};
-  return plugin_main(&handover);
+    sdk_handover_t handover = {.src = argv[1], .dst = argv[2], .cfg = argv[3]};
+    return plugin_main(&handover);
 }

--- a/src/plugin-sdk/sdk.c
+++ b/src/plugin-sdk/sdk.c
@@ -1,6 +1,6 @@
 /*************************************************************************
 | tarman                                                                 |
-| Copyright (C) 2024 Alessandro Salerno                                  |
+| Copyright (C) 2024 - 2025 Alessandro Salerno                                  |
 |                                                                        |
 | This program is free software: you can redistribute it and/or modify   |
 | it under the terms of the GNU General Public License as published by   |
@@ -22,9 +22,9 @@
 #include "plugin/sdk.h"
 
 int sdk_exec(const char *executable, ...) {
-  va_list args;
-  va_start(args, executable);
-  int ret = os_vexec(executable, args);
-  va_end(args);
-  return ret;
+    va_list args;
+    va_start(args, executable);
+    int ret = os_vexec(executable, args);
+    va_end(args);
+    return ret;
 }


### PR DESCRIPTION
- Fixed naked `%d` specifiers in CLI output (`aligned_vprintf` in `src/common/cli/output.c`)
- Fixed `-a` option being ignored (`override_recipe` in `src/common/cli/directives/commands/install.c`)
- Fixed pointer-pointer dereferancing in recipe warning (`util_pkg_parse_config` in `src/common/util/pkg.c`)
- Changed to 4-space indentation
- Updated copyright